### PR TITLE
RHEL-09-251040: Resolve iteration issue

### DIFF
--- a/tasks/Cat2/RHEL-09-25xxxx.yml
+++ b/tasks/Cat2/RHEL-09-25xxxx.yml
@@ -195,16 +195,18 @@
     - name: "MEDIUM | RHEL-09-251040 | PATCH | RHEL 9 network interfaces must not be in promiscuous mode."
       when:
         - not rhel9stig_disruption_high
-        - item not in rhel9stig_promisc_if
+        - item in rhel9stig_promisc_if
       ansible.builtin.debug:
         msg: "Warning!! You have interfaces set to promicious mode no in the exception list"
+      loop: "{{ ansible_facts.interfaces }}"
 
     - name: "MEDIUM | RHEL-09-251040 | PATCH | RHEL 9 network interfaces must not be in promiscuous mode."
       when:
         - not rhel9stig_disruption_high
-        - item not in rhel9stig_promisc_if
-      ansible.builtin.import_tasks:
+        - item in rhel9stig_promisc_if
+      ansible.builtin.include_tasks:
         file: warning_facts.yml
+      loop: "{{ ansible_facts.interfaces }}"
 
 - name: "MEDIUM | RHEL-09-251045 | PATCH | RHEL 9 must enable hardening for the Berkeley Packet Filter just-in-time compiler."
   when:


### PR DESCRIPTION
Overall Review of Changes:
Loop over each task in this block, that way item is defined. Correct the boolean logic for warning/logging for interfaces. Warnings should be issued if an interface in ansible_facts.interfaces is allowed in promiscuous mode.
Issue Fixes:
Please list (using linking) any open issues this PR addresses
https://github.com/ansible-lockdown/RHEL9-STIG/issues/1
Enhancements:
Please list any enhancements/features that are not open issue tickets

How has this been tested?:
Tested on fresh install of RHEL 9.3 via the network boot iso.

This is a resubmit, going into devel.