### PR TITLE
fix(rhel_09_252035): fix templating and resolv.conf template syntax

### DIFF
--- a/tasks/Cat2/RHEL-09-25xxxx.yml
+++ b/tasks/Cat2/RHEL-09-25xxxx.yml
@@ -331,9 +331,9 @@
           rhel9stig_network_manager_dns.stdout == 'none' or
           rhel9stig_network_manager_dns.stdout == 'unmanaged'
       ansible.builtin.template:
-        dest: /etc/resolv.conf.j2
+        dest: /etc/resolv.conf
         mode: '0644'
-        src: /etc/resolv.conf
+        src: etc/resolv.conf.j2
 
     - name: "MEDIUM | RHEL-09-252035 | PATCH | RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least two name servers configured."
       when:

--- a/templates/etc/resolv.conf.j2
+++ b/templates/etc/resolv.conf.j2
@@ -3,7 +3,7 @@
 # Sponsored by MindPointGroup.com
 {% if rhel9stig_resolv_domains is defined %}
 # Domains
-{% for domains in rhel9stig_resolv_domains
+{% for domains in rhel9stig_resolv_domains %}
 domain {{ rhel9stig_resolv_domains }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
**Overall Review of Changes:**
 fix templating for rhel_09_252035 and resolv.conf  jinja template syntax

**Issue Fixes:**
[RHEL-09-252035 missing /etc/resolv.conf](https://github.com/ansible-lockdown/RHEL9-STIG/issues/25)

**Enhancements:**
Fixed jinja template syntax for etc/resolv.conf

**How has this been tested?:**
Deployed to RHEL9 vm to VMware vSphere using packer with the ansible provider to apply STIG lockdown

