### PR TITLE
Dynamically set rhel9stig_gui variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -597,8 +597,8 @@ rhel_09_653120: true
 
 ### CONTROLS
 
-## Grahical/Gnome interface required
-rhel9stig_gui: false
+## Graphical/Gnome interface required
+rhel9stig_gui: "{{ rhel_09_gnome_present.stat.exists | default(false) }}"
 
 ## SSHD
 rhel9stig_sshd_config_file: /etc/ssh/sshd_config

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -210,6 +210,13 @@
   failed_when: rhel9stig_network_manager_dns.rc not in [ 0, 1 ]
   register: rhel9stig_network_manager_dns
 
+- name: PRELIM | Discover Gnome Desktop Environment
+  tags:
+    - always
+  ansible.builtin.stat:
+    path: /usr/share/gnome/gnome-version.xml
+  register: rhel_09_gnome_present
+
 - name: PRELIM | Discover dconf systemdb
   when:
     - rhel9stig_gui


### PR DESCRIPTION
**Overall Review of Changes:**
I believe this role would be improved by dynamically determining if the target system to be locked down has Gnome Desktop installed or not. This makes management of the inventory easier and based on my analysis there is not a justification to set this variable statically.

This could be accomplished in a number of ways, I chose to stat the gnome-version.xml file that is installed when the Gnome Desktop packages are installed.

**Issue Fixes:**
N/A

**Enhancements:**
Quality of life improvement

**How has this been tested?:**
Built a fresh Rocky 9 VM with Gnome Desktop installed and executed the entire role.

