### PR TITLE
Address #34 by making prelim task conditions "or"

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -235,10 +235,10 @@
 
 - name: PRELIM | Find all sudoers files.
   when:
-    - rhel_09_432015
-    - rhel_09_432020
-    - rhel_09_432025
-    - rhel_09_432030
+    - rhel_09_432015 or
+      rhel_09_432020 or
+      rhel_09_432025 or
+      rhel_09_432030
   tags:
     - always
   ansible.builtin.shell: find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'
@@ -249,10 +249,10 @@
 
 - name: PRELIM | Find all pwquality files.
   when:
-    - rhel_09_611100
-    - rhel_09_611060
-    - rhel_09_611065
-    - rhel_09_611070
+    - rhel_09_611100 or
+      rhel_09_611060 or
+      rhel_09_611065 or
+      rhel_09_611070
   tags:
     - always
   ansible.builtin.shell: find /etc/security/pwquality.conf /etc/security/pwquality.conf.d/*.conf


### PR DESCRIPTION
**Overall Review of Changes:**
Switch conditions for `PRELIM | Find all sudoers files.` and `PRELIM | Find all pwquality files.` to be an "or" not an "and", as none of the controls that use the variables these tasks register have explicit requirements on any other control that uses the variable.

**Issue Fixes:**
#34 

**Enhancements:**
N/A

**How has this been tested?:**
`pre-commit run` passed, changes were also successfully applied to a machine. With rhel_09_432015 disabled, the "Find all sudoers files" task still ran, and the rest of the playbook completely successfully.

