### PR TITLE
Changed quotations around lines using variables

### DIFF
--- a/tasks/Cat2/RHEL-09-61xxxx.yml
+++ b/tasks/Cat2/RHEL-09-61xxxx.yml
@@ -380,7 +380,7 @@
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: \s*lcredit =
-    line: lcredit = "{{ rhel9stig_pwquality.lcredit }}"
+    line: "lcredit = {{ rhel9stig_pwquality.lcredit }}"
     backrefs: true
   loop: "{{ rhel9stig_pwquality_conf_files.stdout_lines }}"
 
@@ -399,7 +399,7 @@
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: \s*dcredit =
-    line: dcredit = "{{ rhel9stig_pwquality.dcredit }}"
+    line: "dcredit = {{ rhel9stig_pwquality.dcredit }}"
     backrefs: true
   loop: "{{ rhel9stig_pwquality_conf_files.stdout_lines }}"
 
@@ -418,7 +418,7 @@
   ansible.builtin.lineinfile:
     path: /etc/login.defs
     regexp: \s*PASS_MIN_DAYS\s*
-    line: PASS_MIN_DAYS "{{ rhel9stig_pass.min_days }}"
+    line: "PASS_MIN_DAYS {{ rhel9stig_pass.min_days }}"
     backrefs: true
 
 - name: "MEDIUM | RHEL-09-611080 | PATCH | RHEL 9 passwords must have a 24 hours minimum password lifetime restriction in /etc/shadow."
@@ -527,7 +527,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/pwquality.conf
     regexp: \s*minlen\s*=\s*([0-9]|1[0-4])
-    line: minlen = "{{ rhel9stig_pass.minlen }}"
+    line: "minlen = {{ rhel9stig_pass.minlen }}"
     backrefs: true
 
 - name: "MEDIUM | RHEL-09-611095 | PATCH | RHEL 9 passwords for new users must have a minimum of 15 characters."
@@ -544,7 +544,7 @@
   ansible.builtin.lineinfile:
     path: /etc/login.defs
     regexp: PASS_MIN_LEN
-    line: PASS_MIN_LEN "{{ rhel9stig_pass.minlen }}"
+    line: "PASS_MIN_LEN {{ rhel9stig_pass.minlen }}"
     backrefs: true
 
 - name: "MEDIUM | RHEL-09-611100 | PATCH | RHEL 9 must enforce password complexity by requiring that at least one special character be used."
@@ -562,7 +562,7 @@
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: \s*ocredit =
-    line: ocredit = "{{ rhel9stig_pwquality.ocredit }}"
+    line: "ocredit = {{ rhel9stig_pwquality.ocredit }}"
     backrefs: true
   loop: "{{ rhel9stig_pwquality_conf_files.stdout_lines }}"
 
@@ -581,7 +581,7 @@
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: \s*dictcheck\s*=\s*
-    line: dictcheck="{{ rhel9stig_pwquality.dictcheck }}"
+    line: "dictcheck={{ rhel9stig_pwquality.dictcheck }}"
     backrefs: true
   loop: "{{ rhel9stig_pwquality_conf_files.stdout_lines }}"
 
@@ -600,7 +600,7 @@
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: \s*ucredit\s*=\s*
-    line: ucredit = "{{ rhel9stig_pwquality.ucredit }}"
+    line: "ucredit = {{ rhel9stig_pwquality.ucredit }}"
     backrefs: true
   loop: "{{ rhel9stig_pwquality_conf_files.stdout_lines }}"
 
@@ -619,7 +619,7 @@
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: \s*difok\s*=\s*
-    line: difok = "{{ rhel9stig_pwquality.difok }}"
+    line: "difok = {{ rhel9stig_pwquality.difok }}"
     backrefs: true
   loop: "{{ rhel9stig_pwquality_conf_files.stdout_lines }}"
 
@@ -638,7 +638,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/pwquality.conf
     regexp: \s*maxclassrepeat\s*=\s*
-    line: maxclassrepeat = "{{ rhel9stig_pwquality.maxclassrepeat }}"
+    line: "maxclassrepeat = {{ rhel9stig_pwquality.maxclassrepeat }}"
     backrefs: true
 
 - name: "MEDIUM | RHEL-09-611125 | PATCH | RHEL 9 must require the maximum number of repeating characters be limited to three when passwords are changed."
@@ -656,7 +656,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/pwquality.conf
     regexp: \s*maxrepeat\s*=\s*
-    line: maxrepeat = "{{ rhel9stig_pwquality.maxrepeat }}"
+    line: "maxrepeat = {{ rhel9stig_pwquality.maxrepeat }}"
     backrefs: true
 
 - name: "MEDIUM | RHEL-09-611130 | PATCH | RHEL 9 must require the change of at least four character classes when passwords are changed."
@@ -674,7 +674,7 @@
   ansible.builtin.lineinfile:
     path: /etc/security/pwquality.conf
     regexp: \s*minclass\s*=\s*
-    line: minclass = "{{ rhel9stig_pwquality.minclass }}"
+    line: "minclass = {{ rhel9stig_pwquality.minclass }}"
     backrefs: true
 
 - name: "MEDIUM | RHEL-09-611135 | PATCH | RHEL 9 must be configured so that user and group account administration utilities are configured to store only encrypted representations of passwords."


### PR DESCRIPTION
**Overall Review of Changes:**
Changed the way quotations are used around variables to prevent the quotes from being transferred to file

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL9-STIG/issues/47

**How has this been tested?:**
Tested on a test VM

