### PR TITLE
removed check for aide being already installed

### DIFF
--- a/tasks/Cat2/RHEL-09-65xxxx.yml
+++ b/tasks/Cat2/RHEL-09-65xxxx.yml
@@ -4,7 +4,6 @@
   when:
     - rhel_09_651010
     - rhel9stig_use_aide
-    - "'aide' not in ansible_facts.packages"
   tags:
     - RHEL-09-651010
     - CAT2

--- a/tasks/Cat2/RHEL-09-65xxxx.yml
+++ b/tasks/Cat2/RHEL-09-65xxxx.yml
@@ -17,6 +17,7 @@
     - NIST800-53R4_SI-6
     - aide
   notify: Build_aide_db
+  changed_when: true
   ansible.builtin.package:
     name: aide
     state: present


### PR DESCRIPTION
**Overall Review of Changes:**
Remove check of aide being installed or not

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL9-STIG/issues/51


**How has this been tested?:**
Tested on a VM

