### PR TITLE
Auditd Task and Variable Updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -852,6 +852,7 @@ rhel9stig_remotelog_server:
 # Ensure this matches the filesystem where the audit logs are stored.
 # It will affect checks for control RHEL-09-653030
 
+rhel9stig_auditd_required: true
 rhel9stig_audit_log_filesystem: '/var/log/audit'
 rhel9stig_audit_conf:
   action_mail_acct: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -871,5 +871,12 @@ rhel9stig_audit_conf:
   space_left: 25%
   space_left_action: email
   write_logs: 'yes'
-
 rhel9stig_audit_backlog_limit: 8192
+rhel9stig_audit_bins:
+- '/usr/sbin/auditctl'
+- '/usr/sbin/aureport'
+- '/usr/sbin/ausearch'
+- '/usr/sbin/autrace'
+- '/usr/sbin/auditd'
+- '/usr/sbin/rsyslogd'
+- '/usr/sbin/augenrules'

--- a/tasks/Cat2/RHEL-09-232xxx.yml
+++ b/tasks/Cat2/RHEL-09-232xxx.yml
@@ -129,7 +129,7 @@
     mode: 'u+x,go-w'
     modification_time: preserve
     owner: root
-  loop: "{{ audit_bins }}"
+  loop: "{{ rhel9stig_audit_bins }}"
 
 - name: "MEDIUM | RHEL-09-232040 | PATCH | RHEL 9 cron configuration directories must have a mode of 0700 or less permissive."
   when: rhel_09_232040
@@ -832,7 +832,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     owner: root
-  loop: "{{ audit_bins }}"
+  loop: "{{ rhel9stig_audit_bins }}"
 
 - name: "MEDIUM | RHEL-09-232225 | PATCH | RHEL 9 audit tools must be group-owned by root."
   when: rhel_09_232225
@@ -847,7 +847,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     group: root
-  loop: "{{ audit_bins }}"
+  loop: "{{ rhel9stig_audit_bins }}"
 
 - name: "MEDIUM | RHEL-09-232230 | PATCH | RHEL 9 cron configuration files directory must be owned by root."
   when: rhel_09_232230

--- a/tasks/Cat2/RHEL-09-652xxx.yml
+++ b/tasks/Cat2/RHEL-09-652xxx.yml
@@ -109,7 +109,9 @@
 
 ## Required for 652035 to run
 - name: "MEDIUM | RHEL-09-653130 | PATCH | RHEL 9 audispd-plugins package must be installed"
-  when: rhel_09_653130
+  when:
+    - rhel_09_653130
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653130
     - CAT2

--- a/tasks/Cat2/RHEL-09-653xxx.yml
+++ b/tasks/Cat2/RHEL-09-653xxx.yml
@@ -1,6 +1,8 @@
 ---
 - name: "MEDIUM | RHEL-09-653010 | PATCH | RHEL 9 audit package must be installed."
-  when: rhel_09_653010
+  when:
+    - rhel_09_653010
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653010
     - CAT2
@@ -69,7 +71,9 @@
     state: present
 
 - name: "MEDIUM | RHEL-09-653015 | PATCH | RHEL 9 audit service must be enabled"
-  when: rhel_09_653015
+  when:
+    - rhel_09_653015
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653015
     - CAT2
@@ -139,7 +143,9 @@
     state: started
 
 - name: "MEDIUM | RHEL-09-653020 | PATCH | RHEL 9 audit system must take appropriate action when an error writing to the audit storage volume occurs."
-  when: rhel_09_653020
+  when:
+    - rhel_09_653020
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653020
     - CAT2
@@ -155,7 +161,9 @@
     line: disk_error_action = {{ rhel9stig_audit_conf.disk_error_action }}
 
 - name: "MEDIUM | RHEL-09-653025 | PATCH | RHEL 9 audit system must take appropriate action when the audit storage volume is full."
-  when: rhel_09_653025
+  when:
+    - rhel_09_653025
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653055
     - CAT2
@@ -171,7 +179,9 @@
     line: disk_full_action = {{ rhel9stig_audit_conf.disk_full_action }}
 
 - name: "MEDIUM | RHEL-09-653030 | AUDIT | RHEL 9 must allocate audit record storage capacity to store at least one week's worth of audit records."
-  when: rhel_09_653030
+  when:
+    - rhel_09_653030
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653030
     - CAT2
@@ -207,7 +217,9 @@
 
 - name: "MEDIUM | RHEL-09-653035 | PATCH | RHEL 9 must take action when allocated audit record storage volume reaches 75 percent of the repository maximum audit record
     storage capacity."
-  when: rhel_09_653035
+  when:
+    - rhel_09_653035
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653035
     - CAT2
@@ -224,7 +236,9 @@
 
 - name: "MEDIUM | RHEL-09-653040 | PATCH | RHEL 9 must notify the system administrator (SA) and information system security officer (ISSO) (at a minimum) when allocated
     audit record storage volume 75 percent utilization."
-  when: rhel_09_653040
+  when:
+    - rhel_09_653040
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653040
     - CAT2
@@ -240,7 +254,9 @@
     line: space_left_action = {{ rhel9stig_audit_conf.space_left_action }}
 
 - name: "MEDIUM | RHEL-09-653045 | PATCH | RHEL 9 must take action when allocated audit record storage volume reaches 95 percent of the audit record storage capacity."
-  when: rhel_09_653045
+  when:
+    - rhel_09_653045
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653045
     - CAT2
@@ -257,7 +273,9 @@
 
 - name: "MEDIUM | RHEL-09-653050 | PATCH | RHEL 9 must take action when allocated audit record storage volume reaches 95 percent of the repository maximum audit record
     storage capacity."
-  when: rhel_09_653050
+  when:
+    - rhel_09_653050
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653050
     - CAT2
@@ -273,7 +291,9 @@
     line: admin_space_left_action = {{ rhel9stig_audit_conf.admin_space_left_action }}
 
 - name: "MEDIUM | RHEL-09-653055 | PATCH | RHEL 9 audit system must take appropriate action when the audit files have reached maximum size."
-  when: rhel_09_653055
+  when:
+    - rhel_09_653055
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653055
     - CAT2
@@ -289,7 +309,9 @@
     line: max_log_file_action = {{ rhel9stig_audit_conf.max_log_file_action }}
 
 - name: "MEDIUM | RHEL-09-653060 | PATCH | RHEL 9 must label all offloaded audit logs before sending them to the central log server."
-  when: rhel_09_653060
+  when:
+    - rhel_09_653060
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653060
     - CAT2
@@ -306,7 +328,9 @@
     line: name_format = {{ rhel9stig_audit_conf.name_format }}
 
 - name: "MEDIUM | RHEL-09-653065 | PATCH | RHEL 9 must take appropriate action when the internal event queue is full."
-  when: rhel_09_653065
+  when:
+    - rhel_09_653065
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653065
     - CAT2
@@ -323,7 +347,9 @@
 
 - name: "MEDIUM | RHEL-09-653070 | PATCH | RHEL 9 System Administrator (SA) and/or information system security officer (ISSO) (at a minimum) must be alerted of an
     audit processing failure event."
-  when: rhel_09_653070
+  when:
+    - rhel_09_653070
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653070
     - CAT2
@@ -342,7 +368,9 @@
     line: overflow_action = {{ rhel9stig_audit_conf.overflow_action }}
 
 - name: "MEDIUM | RHEL-09-653075 | PATCH | RHEL 9 audit system must audit local events."
-  when: rhel_09_653075
+  when:
+    - rhel_09_653075
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653075
     - CAT2
@@ -361,7 +389,9 @@
     line: overflow_action = {{ rhel9stig_audit_conf.overflow_action }}
 
 - name: "MEDIUM | RHEL-09-653080 | PATCH | RHEL 9 audit logs must be group-owned by root or by a restricted logging group to prevent unauthorized read access."
-  when: rhel_09_653080
+  when:
+    - rhel_09_653080
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653080
     - CAT2
@@ -391,7 +421,9 @@
         group: "{{ rhel9stig_audit_conf.logfile_group }}"
 
 - name: "MEDIUM | RHEL-09-653085 | PATCH | RHEL 9 audit log directory must be owned by root to prevent unauthorized read access."
-  when: rhel_09_653085
+  when:
+    - rhel_09_653085
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653085
     - CAT2
@@ -411,7 +443,9 @@
     owner: root
 
 - name: "MEDIUM | RHEL-09-653090 | PATCH | RHEL 9 audit logs file must have mode 0600 or less permissive to prevent unauthorized access to the audit log."
-  when: rhel_09_653090
+  when:
+    - rhel_09_653090
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653090
     - CAT2
@@ -431,7 +465,9 @@
     mode: "go-rwx"
 
 - name: "MEDIUM | RHEL-09-653095 | PATCH | RHEL 9 must periodically flush audit records to disk to prevent the loss of audit records."
-  when: rhel_09_653095
+  when:
+    - rhel_09_653095
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653095
     - CAT2
@@ -448,7 +484,9 @@
 
 - name: "MEDIUM | RHEL-09-653100 | PATCH | RHEL 9 must produce audit records containing information to establish the identity of any individual or process associated
     with the event."
-  when: rhel_09_653100
+  when:
+    - rhel_09_653100
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653100
     - CAT2
@@ -467,7 +505,9 @@
     line: log_format = {{ rhel9stig_audit_conf.log_format }}
 
 - name: "MEDIUM | RHEL-09-653105 | PATCH | RHEL 9 must write audit records to disk."
-  when: rhel_09_653105
+  when:
+    - rhel_09_653105
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653105
     - CAT2
@@ -484,7 +524,9 @@
 
 - name: "MEDIUM | RHEL-09-653110 | PATCH | RHEL 9 must allow only the information system security manager (ISSM) (or individuals or roles appointed by the ISSM) to
     select which auditable events are to be audited."
-  when: rhel_09_653110
+  when:
+    - rhel_09_653110
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653110
     - CAT2
@@ -510,7 +552,9 @@
         - "etc/audit/rules.d/*.rules"
 
 - name: "MEDIUM | RHEL-09-653115 | PATCH | RHEL 9 /etc/audit/auditd.conf file must have 0640 or less permissive to prevent unauthorized access."
-  when: rhel_09_653115
+  when:
+    - rhel_09_653115
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-653115
     - CAT2

--- a/tasks/Cat2/RHEL-09-654xxx.yml
+++ b/tasks/Cat2/RHEL-09-654xxx.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "MEDIUM | RHEL-09-654010 | PATCH | RHEL 9 must audit uses of the 'execve' system call."
-  when: rhel_09_654010
+  when:
+    - rhel_09_654010
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654010
     - CAT2
@@ -17,7 +19,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654015 | PATCH | RHEL 9 must audit all uses of the chmod, fchmod, and fchmodat system calls."
-  when: rhel_09_654015
+  when:
+    - rhel_09_654015
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654015
     - CAT2
@@ -45,7 +49,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654020 | PATCH | RHEL 9 must audit all uses of the chown, fchown, fchownat, and lchown system calls."
-  when: rhel_09_654020
+  when:
+    - rhel_09_654020
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654020
     - CAT2
@@ -74,7 +80,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654025 | PATCH | RHEL 9 must audit all uses of the setxattr, fsetxattr, lsetxattr, removexattr, fremovexattr, and lremovexattr system calls."
-  when: rhel_09_654025
+  when:
+    - rhel_09_654025
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654025
     - CAT2
@@ -103,7 +111,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654030 | PATCH | RHEL 9 must audit all uses of umount system calls."
-  when: rhel_09_654030
+  when:
+    - rhel_09_654030
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654030
     - CAT2
@@ -126,7 +136,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654035 | PATCH | RHEL 9 must audit all uses of the chacl command."
-  when: rhel_09_654035
+  when:
+    - rhel_09_654035
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654035
     - CAT2
@@ -152,7 +164,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654040 | PATCH | RHEL 9 must audit all uses of the setfacl command."
-  when: rhel_09_654040
+  when:
+    - rhel_09_654040
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654040
     - CAT2
@@ -177,7 +191,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654045 | PATCH | RHEL 9 must audit all uses of the chcon command."
-  when: rhel_09_654045
+  when:
+    - rhel_09_654045
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654045
     - CAT2
@@ -205,7 +221,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654050 | PATCH | RHEL 9 must audit all uses of the semanage command."
-  when: rhel_09_654050
+  when:
+    - rhel_09_654050
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654050
     - CAT2
@@ -232,7 +250,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654055 | PATCH | RHEL 9 must audit all uses of the setfiles command."
-  when: rhel_09_654055
+  when:
+    - rhel_09_654055
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654055
     - CAT2
@@ -259,7 +279,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654060 | PATCH | RHEL 9 must audit all uses of the setsebool command."
-  when: rhel_09_654060
+  when:
+    - rhel_09_654060
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654060
     - CAT2
@@ -286,7 +308,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654065 | PATCH | RHEL 9 must audit all uses of the rename, unlink, rmdir, renameat, and unlinkat system calls."
-  when: rhel_09_654065
+  when:
+    - rhel_09_654065
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654065
     - CAT2
@@ -314,7 +338,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654070 | PATCH | RHEL 9 must audit all uses of the truncate, ftruncate, creat, open, openat, and open_by_handle_at system calls."
-  when: rhel_09_654070
+  when:
+    - rhel_09_654070
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654070
     - CAT2
@@ -342,7 +368,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654075 | PATCH | RHEL 9 must audit all uses of the delete_module system call."
-  when: rhel_09_654075
+  when:
+    - rhel_09_654075
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654075
     - CAT2
@@ -369,7 +397,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654080 | PATCH | RHEL 9 must audit all uses of the init_module and finit_module system calls."
-  when: rhel_09_654080
+  when:
+    - rhel_09_654080
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654080
     - CAT2
@@ -396,7 +426,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654085 | PATCH | RHEL 9 must audit all uses of the chage command."
-  when: rhel_09_654085
+  when:
+    - rhel_09_654085
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654085
     - CAT2
@@ -422,7 +454,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654090 | PATCH | RHEL 9 must audit all uses of the chsh command."
-  when: rhel_09_654090
+  when:
+    - rhel_09_654090
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654090
     - CAT2
@@ -447,7 +481,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654095 | PATCH | RHEL 9 must audit all uses of the crontab command."
-  when: rhel_09_654095
+  when:
+    - rhel_09_654095
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654095
     - CAT2
@@ -472,7 +508,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654100 | PATCH | RHEL 9 must audit all uses of the gpasswd command."
-  when: rhel_09_654100
+  when:
+    - rhel_09_654100
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654100
     - CAT2
@@ -497,7 +535,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654105 | PATCH | RHEL 9 must audit all uses of the kmod command."
-  when: rhel_09_654105
+  when:
+    - rhel_09_654105
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654105
     - CAT2
@@ -524,7 +564,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654110 | PATCH | RHEL 9 must audit all uses of the newgrp command."
-  when: rhel_09_654110
+  when:
+    - rhel_09_654110
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654110
     - CAT2
@@ -549,7 +591,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654115 | PATCH | RHEL 9 must audit all uses of the pam_timestamp_check command."
-  when: rhel_09_654115
+  when:
+    - rhel_09_654115
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654115
     - CAT2
@@ -574,7 +618,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654120 | PATCH | RHEL 9 must audit all uses of the passwd command."
-  when: rhel_09_654120
+  when:
+    - rhel_09_654120
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654120
     - CAT2
@@ -599,7 +645,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654125 | PATCH | RHEL 9 must audit all uses of the postdrop command."
-  when: rhel_09_654125
+  when:
+    - rhel_09_654125
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654125
     - CAT2
@@ -624,7 +672,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654130 | PATCH | RHEL 9 must audit all uses of the postqueue command."
-  when: rhel_09_654130
+  when:
+    - rhel_09_654130
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654130
     - CAT2
@@ -649,7 +699,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654135 | PATCH | RHEL 9 must audit all uses of the ssh-agent command."
-  when: rhel_09_654135
+  when:
+    - rhel_09_654135
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654135
     - CAT2
@@ -674,7 +726,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654140 | PATCH | RHEL 9 must audit all uses of the ssh-keysign command."
-  when: rhel_09_654140
+  when:
+    - rhel_09_654140
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654140
     - CAT2
@@ -699,7 +753,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654145 | PATCH | RHEL 9 must audit all uses of the su command."
-  when: rhel_09_654145
+  when:
+    - rhel_09_654145
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654145
     - CAT2
@@ -726,7 +782,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654150 | PATCH | RHEL 9 must audit all uses of the sudo command."
-  when: rhel_09_654150
+  when:
+    - rhel_09_654150
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654150
     - CAT2
@@ -752,7 +810,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654155 | PATCH | RHEL 9 must audit all uses of the sudoedit command."
-  when: rhel_09_654155
+  when:
+    - rhel_09_654155
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654155
     - CAT2
@@ -777,7 +837,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654160 | PATCH | RHEL 9 must audit all uses of the unix_chkpwd command."
-  when: rhel_09_654160
+  when:
+    - rhel_09_654160
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654160
     - CAT2
@@ -802,7 +864,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654165 | PATCH | RHEL 9 must audit all uses of the unix_update command."
-  when: rhel_09_654165
+  when:
+    - rhel_09_654165
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654165
     - CAT2
@@ -828,7 +892,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654170 | PATCH | RHEL 9 must audit all uses of the userhelper command."
-  when: rhel_09_654170
+  when:
+    - rhel_09_654170
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654170
     - CAT2
@@ -853,7 +919,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654175 | PATCH | RHEL 9 must audit all uses of the usermod command."
-  when: rhel_09_654175
+  when:
+    - rhel_09_654175
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654175
     - CAT2
@@ -879,7 +947,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654180 | PATCH | RHEL 9 must audit all uses of the mount command."
-  when: rhel_09_654180
+  when:
+    - rhel_09_654180
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654180
     - CAT2
@@ -904,7 +974,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654185 | PATCH | Successful/unsuccessful uses of the init command in RHEL 9 must generate an audit record."
-  when: rhel_09_654185
+  when:
+    - rhel_09_654185
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654185
     - CAT2
@@ -918,7 +990,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654190 | PATCH | Successful/unsuccessful uses of the poweroff command in RHEL 9 must generate an audit record."
-  when: rhel_09_654190
+  when:
+    - rhel_09_654190
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654190
     - CAT2
@@ -932,7 +1006,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654195 | PATCH | Successful/unsuccessful uses of the reboot command in RHEL 9 must generate an audit record."
-  when: rhel_09_654195
+  when:
+    - rhel_09_654195
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654195
     - CAT2
@@ -946,7 +1022,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654200 | PATCH | Successful/unsuccessful uses of the shutdown command in RHEL 9 must generate an audit record."
-  when: rhel_09_654200
+  when:
+    - rhel_09_654200
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654200
     - CAT2
@@ -960,7 +1038,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654205 | PATCH | Successful/unsuccessful uses of the umount system call in RHEL 9 must generate an audit record."
-  when: rhel_09_654205
+  when:
+    - rhel_09_654205
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654205
     - CAT2
@@ -983,7 +1063,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654210 | PATCH | Successful/unsuccessful uses of the umount2 system call in RHEL 9 must generate an audit record."
-  when: rhel_09_654210
+  when:
+    - rhel_09_654210
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654210
     - CAT2
@@ -1006,7 +1088,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654215 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/sudoers."
-  when: rhel_09_654215
+  when:
+    - rhel_09_654215
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654215
     - CAT2
@@ -1047,7 +1131,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654220 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/sudoers.d/ directory."
-  when: rhel_09_654220
+  when:
+    - rhel_09_654220
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654220
     - CAT2
@@ -1088,7 +1174,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654225 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group."
-  when: rhel_09_654225
+  when:
+    - rhel_09_654225
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654225
     - CAT2
@@ -1129,7 +1217,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654230 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow."
-  when: rhel_09_654230
+  when:
+    - rhel_09_654230
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654230
     - CAT2
@@ -1170,7 +1260,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654235 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/opasswd."
-  when: rhel_09_654235
+  when:
+    - rhel_09_654235
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654235
     - CAT2
@@ -1211,7 +1303,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654240 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd."
-  when: rhel_09_654240
+  when:
+    - rhel_09_654240
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654240
     - CAT2
@@ -1260,7 +1354,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654245 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow."
-  when: rhel_09_654240
+  when:
+    - rhel_09_654240
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654240
     - CAT2
@@ -1301,7 +1397,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654250 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /var/log/faillock."
-  when: rhel_09_654250
+  when:
+    - rhel_09_654250
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654250
     - CAT2
@@ -1319,7 +1417,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654255 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /var/log/lastlog."
-  when: rhel_09_654255
+  when:
+    - rhel_09_654255
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654255
     - CAT2
@@ -1345,7 +1445,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654260 | PATCH | RHEL 9 must generate audit records for all account creations, modifications, disabling, and termination events that affect /var/log/tallylog."
-  when: rhel_09_654260
+  when:
+    - rhel_09_654260
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654260
     - CAT2
@@ -1363,7 +1465,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654265 | PATCH | RHEL 9 must take appropriate action when a critical audit processing failure occurs."
-  when: rhel_09_654265
+  when:
+    - rhel_09_654265
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654265
     - CAT2
@@ -1379,7 +1483,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654270 | PATCH | RHEL 9 audit system must protect logon UIDs from unauthorized change."
-  when: rhel_09_654270
+  when:
+    - rhel_09_654270
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654270
     - CAT2
@@ -1401,7 +1507,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654275 | PATCH | RHEL 9 audit system must protect auditing rules from unauthorized change."
-  when: rhel_09_654275
+  when:
+    - rhel_09_654275
+    - rhel9stig_auditd_required
   tags:
     - RHEL-09-654275
     - CAT2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,6 +114,7 @@
 - name: Run auditd logic
   when:
     - update_audit_template
+    - rhel9stig_auditd_required
   tags:
     - always
   ansible.builtin.import_tasks:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -126,6 +126,8 @@
     - ansible_facts.distribution != 'OracleLinux'
 
 - name: PRELIM | Configure System Accounting (auditd)
+  when:
+    - rhel9stig_auditd_required
   tags: always
   ansible.builtin.package:
     name: audit
@@ -136,6 +138,7 @@
     - rhel_09_653085 or
       rhel_09_653085 or
       rhel_09_653090
+    - rhel9stig_auditd_required
   tags: always
   ansible.builtin.shell: grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
   changed_when: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -47,13 +47,3 @@ rhel9stig_dod_kex:
 # Defaults added for searches
 rhel9stig_ungrouped_files_found: false
 rhel9stig_unowned_files_found: false
-
-# Audit binaries
-audit_bins:
-- '/usr/sbin/auditctl'
-- '/usr/sbin/aureport'
-- '/usr/sbin/ausearch'
-- '/usr/sbin/autrace'
-- '/usr/sbin/auditd'
-- '/usr/sbin/rsyslogd'
-- '/usr/sbin/augenrules'


### PR DESCRIPTION
**Overall Review of Changes:**
- Moved `audit_bins` variable from `vars/main.yml` to `defaults/main.yml`
- Create new variable `rhel9stig_auditd_required: true` in `defaults/main.yml` and applied it as a when conditional to every auditd related task

**Issue Fixes:**
- https://github.com/ansible-lockdown/RHEL9-STIG/issues/91

**Enhancements:**
- https://github.com/ansible-lockdown/RHEL9-STIG/issues/92

**How has this been tested?:**
On a RHEL9 minimal host
1. dnf -y install ansible git
2. git clone https://github.com/PrymalInstynct/RHEL9-STIG-MPG.git
3. cd RHEL9-STIG-MPG/
4. ansible-galaxy collection install -r collections/requirements.yml
5.  vim inventory.yml
6.  ansible-playbook -i inventory.yml site.yml

- Example Inventory

```yaml
container:
  vars:
    ansible_connection: local
    rhel9stig_auditd_required: false
    rhel9stig_audit_bins:
    - '/usr/sbin/auditctl'
    - '/usr/sbin/aureport'
    - '/usr/sbin/ausearch'
    - '/usr/sbin/autrace'
    - '/usr/sbin/auditd'
    - '/usr/sbin/augenrules'
  hosts:
    localhost:
      ansible_host: 127.0.0.1
```
