### PR TITLE
Sshd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -608,7 +608,7 @@ rhel9stig_gui: "{{ rhel_09_gnome_present.stat.exists | default(false) }}"
 
 ## SSHD
 rhel9stig_sshd_config_file: /etc/ssh/sshd_config
-rhel9stig_ssh_required: true
+rhel9stig_sshd_required: true
 rhel9stig_sshd_config_maxlogins: 10
 rhel9stig_sshd_config:
   banner_file: /etc/issue

--- a/tasks/Cat1/RHEL-09-2xxxxx.yml
+++ b/tasks/Cat1/RHEL-09-2xxxxx.yml
@@ -299,7 +299,9 @@
       ansible.builtin.import_tasks: warning_facts.yml
 
 - name: HIGH | RHEL-09-255040 | PATCH | RHEL 9 SSHD must not allow blank passwords.
-  when: rhel_09_255040
+  when:
+    - rhel_09_255040
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255040
     - CAT1
@@ -321,7 +323,9 @@
     validate: sshd -t -f %s
 
 - name: HIGH | RHEL-09-255050 | PATCH | RHEL 9 must enable the Pluggable Authentication Module (PAM) interface for SSHD.
-  when: rhel_09_255050
+  when:
+    - rhel_09_255050
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255050
     - CAT1

--- a/tasks/Cat2/RHEL-09-211xxx.yml
+++ b/tasks/Cat2/RHEL-09-211xxx.yml
@@ -33,7 +33,7 @@
     - NIST800-53R4_AC-8
   block:
     - name: "MEDIUM | RHEL-09-211020 | PATCH | RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting local or remote access to the system via a command line user logon. | Uncomment banner keyword and set banner path"
-      when: rhel9stig_ssh_required
+      when: rhel9stig_sshd_required
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
         regexp: '(?i)^Banner'

--- a/tasks/Cat2/RHEL-09-211xxx.yml
+++ b/tasks/Cat2/RHEL-09-211xxx.yml
@@ -38,6 +38,7 @@
         path: /etc/ssh/sshd_config
         regexp: '(?i)^Banner'
         line: "Banner {{ rhel9stig_sshd_config.banner_file }}"
+      notify: Sshd_restart
 
     - name: "MEDIUM | RHEL-09-211020 | PATCH | RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting local or remote access to the system via a command line user logon. | Set banner message"
       ansible.builtin.copy:  # noqa: template-instead-of-copy
@@ -46,7 +47,6 @@
         group: root
         mode: '0644'
         owner: root
-      notify: Sshd_restart
       loop:
         - /etc/issue
         - /etc/issue.net

--- a/tasks/Cat2/RHEL-09-255xxx.yml
+++ b/tasks/Cat2/RHEL-09-255xxx.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "MEDIUM | RHEL-09-255010 | PATCH | All RHEL 9 networked systems must have SSH installed."
-  when: rhel_09_255010
+  when:
+    - rhel_09_255010
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255010
     - CAT2
@@ -21,7 +23,9 @@
     state: present
 
 - name: "MEDIUM | RHEL-09-255015 | PATCH | All RHEL 9 networked systems must have and implement SSH to protect the confidentiality and integrity of transmitted and received information, as well as information during preparation for transmission."
-  when: rhel_09_255015
+  when:
+    - rhel_09_255015
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255015
     - CAT2
@@ -55,7 +59,9 @@
     state: present
 
 - name: "MEDIUM | RHEL-09-255025 | PATCH | RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting local or remote access to the system via a SSH logon."
-  when: rhel_09_255025
+  when:
+    - rhel_09_255025
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255025
     - CAT2
@@ -81,7 +87,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255030 | PATCH | RHEL 9 must log SSH connection attempts and failures to the server."
-  when: rhel_09_255030
+  when:
+    - rhel_09_255030
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255030
     - CAT2
@@ -101,7 +109,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255035 | PATCH | RHEL 9 SSHD must accept public key authentication"
-  when: rhel_09_255035
+  when:
+    - rhel_09_255035
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255035
     - CAT2
@@ -125,7 +135,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255045 | PATCH | RHEL 9 must not permit direct logons to the root account using remote access via SSH."
-  when: rhel_09_255045
+  when:
+    - rhel_09_255045
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255045
     - CAT2
@@ -146,7 +158,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255055 | PATCH | RHEL 9 SSH daemon must be configured to use system-wide crypto policies."
-  when: rhel_09_255055
+  when:
+    - rhel_09_255055
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255055
     - CAT2
@@ -166,7 +180,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255060 | PATCH | RHEL 9 must implement DOD-approved encryption ciphers to protect the confidentiality of SSH client connections."
-  when: rhel_09_255060
+  when:
+    - rhel_09_255060
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255060
     - CAT2
@@ -186,7 +202,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255065 | PATCH | RHEL 9 must implement DOD-approved encryption ciphers to protect the confidentiality of SSH server connections."
-  when: rhel_09_255065
+  when:
+    - rhel_09_255065
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255065
     - CAT2
@@ -202,7 +220,9 @@
     line: "Ciphers {{ rhel9stig_sshd_config.ciphers | join(',') }}"
 
 - name: "MEDIUM | RHEL-09-255075 | PATCH | RHEL 9 SSH server must be configured to use only Message Authentication Codes (MACs) employing FIPS 140-3 validated cryptographic hash algorithms."
-  when: rhel_09_255075
+  when:
+    - rhel_09_255075
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255075
     - CAT2
@@ -218,7 +238,9 @@
     line: "MACs {{ rhel9stig_sshd_config.macs | join(',') }}"
 
 - name: "MEDIUM | RHEL-09-255080 | PATCH | RHEL 9 must not allow a noncertificate trusted host SSH logon to the system."
-  when: rhel_09_255080
+  when:
+    - rhel_09_255080
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255080
     - CAT2
@@ -238,7 +260,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255085 | PATCH | RHEL 9 must not allow users to override SSH environment variables."
-  when: rhel_09_255085
+  when:
+    - rhel_09_255085
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255085
     - CAT2
@@ -258,7 +282,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255090 | PATCH | RHEL 9 must force a frequent session key renegotiation for SSH connections to the server."
-  when: rhel_09_255090
+  when:
+    - rhel_09_255090
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255090
     - CAT2
@@ -283,7 +309,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255095 | PATCH | RHEL 9 must be configured so that all network connections associated with SSH traffic terminate after becoming unresponsive."
-  when: rhel_09_255095
+  when:
+    - rhel_09_255095
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255095
     - CAT2
@@ -307,7 +335,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255100 | PATCH | RHEL 9 must be configured so that all network connections associated with SSH traffic are terminated after 10 minutes of becoming unresponsive."
-  when: rhel_09_255100
+  when:
+    - rhel_09_255100
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255100
     - CAT2
@@ -334,7 +364,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255105 | PATCH | RHEL 9 SSH server configuration file must be group-owned by root."
-  when: rhel_09_255105
+  when:
+    - rhel_09_255105
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255105
     - CAT2
@@ -350,7 +382,9 @@
     mode: 'go-rwx'
 
 - name: "MEDIUM | RHEL-09-255110 | PATCH | RHEL 9 SSH server configuration file must be owned by root."
-  when: rhel_09_255110
+  when:
+    - rhel_09_255110
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255110
     - CAT2
@@ -366,7 +400,9 @@
     mode: 'go-rwx'
 
 - name: "MEDIUM | RHEL-09-255115 | PATCH | RHEL 9 SSH server configuration file must have mode 0600 or less permissive"
-  when: rhel_09_255115
+  when:
+    - rhel_09_255115
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255115
     - CAT2
@@ -381,7 +417,9 @@
     mode: 'go-rwx'
 
 - name: "MEDIUM | RHEL-09-255120 | PATCH | RHEL 9 SSH private host key files must have mode 0640 or less permissive."
-  when: rhel_09_255120
+  when:
+    - rhel_09_255120
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255120
     - CAT2
@@ -405,7 +443,9 @@
       loop: "{{ rhel9stig_private_ssh_keys.files }}"
 
 - name: "MEDIUM | RHEL-09-255125 | PATCH | RHEL 9 SSH public host key files must have mode 0644 or less permissive."
-  when: rhel_09_255125
+  when:
+    - rhel_09_255125
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255125
     - CAT2
@@ -429,7 +469,9 @@
       loop: "{{ rhel9stig_pub_ssh_keys.files }}"
 
 - name: "MEDIUM | RHEL-09-255130 | PATCH | RHEL 9 SSH daemon must not allow compression or must only allow compression after successful authentication."
-  when: rhel_09_255130
+  when:
+    - rhel_09_255130
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255130
     - CAT2
@@ -449,7 +491,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255135 | PATCH | RHEL 9 SSH daemon must not allow GSSAPI authentication."
-  when: rhel_09_255135
+  when:
+    - rhel_09_255135
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255135
     - CAT2
@@ -472,7 +516,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255140 | PATCH | RHEL 9 SSH daemon must not allow Kerberos authentication."
-  when: rhel_09_255140
+  when:
+    - rhel_09_255140
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255140
     - CAT2
@@ -495,7 +541,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255145 | PATCH | RHEL 9 SSH daemon must not allow rhosts authentication"
-  when: rhel_09_255145
+  when:
+    - rhel_09_255145
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255145
     - CAT2
@@ -515,7 +563,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255150 | PATCH | RHEL 9 SSH daemon must not allow known hosts authentication."
-  when: rhel_09_255150
+  when:
+    - rhel_09_255150
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255150
     - CAT2
@@ -535,7 +585,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255155 | PATCH | RHEL 9 SSH daemon must disable remote X connections for interactive users."
-  when: rhel_09_255155
+  when:
+    - rhel_09_255155
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255155
     - CAT2
@@ -555,7 +607,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255160 | PATCH | RHEL 9 SSH daemon must perform strict mode checking of home directory configuration files."
-  when: rhel_09_255160
+  when:
+    - rhel_09_255160
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255160
     - CAT2
@@ -575,7 +629,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255165 | PATCH | RHEL 9 SSH daemon must display the date and time of the last successful account logon upon an SSH logon."
-  when: rhel_09_255165
+  when:
+    - rhel_09_255165
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255165
     - CAT2
@@ -595,7 +651,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255170 | PATCH | RHEL 9 SSH daemon must display the date and time of the last successful account logon upon an SSH logon."
-  when: rhel_09_255170
+  when:
+    - rhel_09_255170
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255170
     - CAT2
@@ -615,7 +673,9 @@
     validate: sshd -t -f %s
 
 - name: "MEDIUM | RHEL-09-255175 | PATCH | RHEL 9 SSH daemon must prevent remote hosts from connecting to the proxy display."
-  when: rhel_09_255175
+  when:
+    - rhel_09_255175
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-255175
     - CAT2

--- a/tasks/Cat2/RHEL-09-654xxx.yml
+++ b/tasks/Cat2/RHEL-09-654xxx.yml
@@ -674,7 +674,9 @@
     update_audit_template: true
 
 - name: "MEDIUM | RHEL-09-654140 | PATCH | RHEL 9 must audit all uses of the ssh-keysign command."
-  when: rhel_09_654140
+  when:
+    - rhel_09_654140
+    - rhel9stig_sshd_required
   tags:
     - RHEL-09-654140
     - CAT2

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -146,6 +146,7 @@
   when:
     - rhel9stig_sshd_config_file != '/etc/ssh/sshd_config'
     - "'openssh-server' in ansible_facts.packages"
+    - rhel9stig_sshd_required
   tags: ssh
   ansible.builtin.file:
     path: "{{ rhel9stig_sshd_config_file }}"
@@ -155,6 +156,7 @@
     state: touch
 
 - name: PRELIM | SSH | find existing ssh config files
+  when: rhel9stig_sshd_required
   tags: always
   ansible.builtin.find:
     paths:

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -632,7 +632,7 @@ rhel9stig_postfix_client_conf: {{ rhel9stig_postfix_client_conf }}
 
 ## SSHD
 rhel9stig_sshd_config_file: {{ rhel9stig_sshd_config_file }}
-rhel9stig_ssh_required: {{ rhel9stig_ssh_required }}
+rhel9stig_sshd_required: {{ rhel9stig_sshd_required }}
 rhel9stig_sshd_config:
   banner_file: {{ rhel9stig_sshd_config.banner_file }}
   ciphers:


### PR DESCRIPTION
**Overall Review of Changes:**
- Changed variable name from `rhel9stig_ssh_required` to `rhel9stig_sshd_required` to emphasize this effects the server daemon only
- Updated all tasks associated with the installation or configuration of openssh-server (sshd)

**Issue Fixes:**
- https://github.com/ansible-lockdown/RHEL9-STIG/issues/90

**Enhancements:**
N/A

**How has this been tested?:**
On a RHEL9 minimal host
1. dnf -y install ansible git
2. git clone https://github.com/PrymalInstynct/RHEL9-STIG-MPG.git
3. cd RHEL9-STIG-MPG/
4. git checkout sshd
5. ansible-galaxy collection install -r collections/requirements.yml
6.  vim inventory.yml
7.  ansible-playbook -i inventory.yml site.yml

- Example Inventory

```yaml
container:
  vars:
    ansible_connection: local
    rhel9stig_sshd_required: false
  hosts:
    localhost:
      ansible_host: 127.0.0.1
```

