### PR TITLE
Adjust audit_bins and created variable for the syslog binary

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -848,6 +848,9 @@ rhel9stig_remotelog_server:
   port: 9999
   protocol: '@@'
 
+# Syslog Binary
+rhel9stig_syslog_bin: rsyslogd
+
 ### AUDITD
 # Ensure this matches the filesystem where the audit logs are stored.
 # It will affect checks for control RHEL-09-653030
@@ -870,5 +873,14 @@ rhel9stig_audit_conf:
   space_left: 25%
   space_left_action: email
   write_logs: 'yes'
-
 rhel9stig_audit_backlog_limit: 8192
+
+# All Audit Binaries
+rhel9stig_audit_bins:
+- '/usr/sbin/auditctl'
+- '/usr/sbin/aureport'
+- '/usr/sbin/ausearch'
+- '/usr/sbin/autrace'
+- '/usr/sbin/auditd'
+- '/usr/sbin/augenrules'
+- '/usr/sbin/{{ rhel9stig_syslog_bin }}'

--- a/tasks/Cat2/RHEL-09-232xxx.yml
+++ b/tasks/Cat2/RHEL-09-232xxx.yml
@@ -129,7 +129,7 @@
     mode: 'u+x,go-w'
     modification_time: preserve
     owner: root
-  loop: "{{ audit_bins }}"
+  loop: "{{ rhel9stig_audit_bins }}"
 
 - name: "MEDIUM | RHEL-09-232040 | PATCH | RHEL 9 cron configuration directories must have a mode of 0700 or less permissive."
   when: rhel_09_232040
@@ -832,7 +832,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     owner: root
-  loop: "{{ audit_bins }}"
+  loop: "{{ rhel9stig_audit_bins }}"
 
 - name: "MEDIUM | RHEL-09-232225 | PATCH | RHEL 9 audit tools must be group-owned by root."
   when: rhel_09_232225
@@ -847,7 +847,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     group: root
-  loop: "{{ audit_bins }}"
+  loop: "{{ rhel9stig_audit_bins }}"
 
 - name: "MEDIUM | RHEL-09-232230 | PATCH | RHEL 9 cron configuration files directory must be owned by root."
   when: rhel_09_232230

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -47,13 +47,3 @@ rhel9stig_dod_kex:
 # Defaults added for searches
 rhel9stig_ungrouped_files_found: false
 rhel9stig_unowned_files_found: false
-
-# Audit binaries
-audit_bins:
-- '/usr/sbin/auditctl'
-- '/usr/sbin/aureport'
-- '/usr/sbin/ausearch'
-- '/usr/sbin/autrace'
-- '/usr/sbin/auditd'
-- '/usr/sbin/rsyslogd'
-- '/usr/sbin/augenrules'


### PR DESCRIPTION
**Overall Review of Changes:**
- Moved vars/main `audit_bins` to defaults/main `rhel9stig_audit_bins`
- Created `rhel9stig_syslog_bin` in defaults/main

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL9-STIG/issues/91

**Enhancements:**
N/A

**How has this been tested?:**
1. Created blank RHEL 9.5 Minimal Server VM from template
#### From Remote Host
2. `git clone git@github.com:PrymalInstynct/RHEL9-STIG-MPG.git`
3. `pushd RHEL9-STIG-MPG`
4. `git checkout audit_bins`
5. Create inventory.yml
6. `ansible-playbook -i inventory.yml site.yml -K`

```yaml
---
all:
  children:
    stig:
      hosts:
        10.10.1.210:
          ansible_ssh_common_args: '-o StrictHostKeyChecking=no'

```
