### PR TITLE
Verify rhel9stig_system_uses_ipv6 & standardize ansible.posix.sysctl usage

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -39,10 +39,6 @@
     name: /var/tmp
     state: remounted
 
-- name: Reload_sysctl
-  ansible.builtin.command: sysctl --system
-  changed_when: true
-
 - name: Rebuild_grub
   ansible.builtin.command: grub2-mkconfig -o /boot/grub2/grub.cfg
   changed_when: true

--- a/tasks/Cat2/RHEL-09-213xxx.yml
+++ b/tasks/Cat2/RHEL-09-213xxx.yml
@@ -13,10 +13,10 @@
     - V-257797
     - NIST800-53R4_SC-2
     - NIST800-53R4_SC-4
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.dmesg_restrict
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '1'
@@ -34,10 +34,10 @@
     - V-257798
     - NIST800-53R4_SC-2
     - NIST800-53R4_SC-4
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.perf_event_paranoid
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '2'
@@ -53,10 +53,10 @@
     - SV-257799r997051_rule
     - V-257799
     - NIST800-53R4_CM-6
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.kexec_load_disabled
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '1'
@@ -74,10 +74,10 @@
     - V-257800
     - NIST800-53R4_CM-6
     - NIST800-53R4_SC-2
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.kptr_restrict
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '1'
@@ -95,10 +95,10 @@
     - V-257801
     - NIST800-53R4_AC-3
     - NIST800-53R4_AC-6
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: fs.protected_hardlinks
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.fs }}"
     sysctl_set: true
     value: '1'
@@ -117,10 +117,10 @@
     - V-257802
     - NIST800-53R4_AC-3
     - NIST800-53R4_AC-6
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: fs.protected_symlinks
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.fs }}"
     sysctl_set: true
     value: '1'
@@ -135,10 +135,10 @@
     - SV-257803r991589_rule
     - V-257803
     - NIST800-53R4_CM-6
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.core_pattern
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '|/bin/false'
@@ -247,10 +247,10 @@
     - V-257809
     - NIST800-53R4_CM-6
     - NIST800-53R4_SI-16
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.randomize_va_space
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '2'
@@ -268,10 +268,10 @@
     - V-257810
     - NIST800-53R4_CM-6
     - NIST800-53R4_SC-2
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.unprivileged_bpf_disabled
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '1'
@@ -289,10 +289,10 @@
     - V-257811
     - NIST800-53R4_CM-6
     - NIST800-53R4_SC-2
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: kernel.yama.ptrace_scope
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.kernel }}"
     sysctl_set: true
     value: '1'
@@ -373,10 +373,10 @@
     - SV-257816r991589_rule
     - V-257816
     - NIST800-53R4_CM-6
-  notify: Reload_sysctl
   ansible.posix.sysctl:
     name: user.max_user_namespaces
     state: present
+    reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.user }}"
     sysctl_set: true
     value: '0'

--- a/tasks/Cat2/RHEL-09-251xxx.yml
+++ b/tasks/Cat2/RHEL-09-251xxx.yml
@@ -220,6 +220,7 @@
     - NIST800-53R4_CM-5
   ansible.posix.sysctl:
     name: net.core.bpf_jit_harden
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '2'

--- a/tasks/Cat2/RHEL-09-253xxx.yml
+++ b/tasks/Cat2/RHEL-09-253xxx.yml
@@ -17,6 +17,7 @@
     - NIST800-53R4_SC-5
   ansible.posix.sysctl:
     name: net.ipv4.tcp_syncookies
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -33,6 +34,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.accept_redirects
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -49,6 +51,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.accept_source_route
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -65,6 +68,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.log_martians
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -81,6 +85,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.default.log_martians
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -97,6 +102,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.rp_filter
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -113,6 +119,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.default.accept_redirects
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -129,6 +136,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.default.accept_source_route
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -145,6 +153,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.default.rp_filter
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -161,6 +170,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.icmp_echo_ignore_broadcasts
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -177,6 +187,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.icmp_ignore_bogus_error_responses
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '1'
@@ -193,6 +204,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.send_redirects
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -209,6 +221,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.default.send_redirects
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -227,6 +240,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.forwarding
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'

--- a/tasks/Cat2/RHEL-09-254xxx.yml
+++ b/tasks/Cat2/RHEL-09-254xxx.yml
@@ -57,6 +57,7 @@
 - name: "MEDIUM | RHEL-09-254025 | PATCH | RHEL 9 must not enable IPv6 packet forwarding unless the system is a router."
   when:
     - rhel_09_254025
+    - rhel9stig_system_uses_ipv6
     - not rhel9stig_system_is_router
   tags:
     - RHEL-09-254025

--- a/tasks/Cat2/RHEL-09-254xxx.yml
+++ b/tasks/Cat2/RHEL-09-254xxx.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "MEDIUM | RHEL-09-254010 | PATCH | RHEL 9 must not accept router advertisements on all IPv6 interfaces."
-  when: rhel_09_254010
+  when:
+    - rhel_09_254010
+    - rhel9stig_system_uses_ipv6
   tags:
     - RHEL-09-254010
     - CAT2
@@ -17,7 +19,9 @@
     value: '0'
 
 - name: "MEDIUM | RHEL-09-254015 | PATCH | RHEL 9 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages."
-  when: rhel_09_254015
+  when:
+    - rhel_09_254015
+    - rhel9stig_system_uses_ipv6
   tags:
     - RHEL-09-254015
     - CAT2
@@ -33,7 +37,9 @@
     value: '0'
 
 - name: "MEDIUM | RHEL-09-254020 | PATCH | RHEL 9 must not forward IPv6 source-routed packets."
-  when: rhel_09_254020
+  when:
+    - rhel_09_254020
+    - rhel9stig_system_uses_ipv6
   tags:
     - RHEL-09-254020
     - CAT2
@@ -67,7 +73,9 @@
     value: '0'
 
 - name: "MEDIUM | RHEL-09-254030 | PATCH | RHEL 9 must not accept router advertisements on all IPv6 interfaces by default."
-  when: rhel_09_254030
+  when:
+    - rhel_09_254030
+    - rhel9stig_system_uses_ipv6
   tags:
     - RHEL-09-254030
     - CAT2
@@ -83,7 +91,9 @@
     value: '0'
 
 - name: "MEDIUM | RHEL-09-254035 | PATCH | RHEL 9 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from being accepted."
-  when: rhel_09_254035
+  when:
+    - rhel_09_254035
+    - rhel9stig_system_uses_ipv6
   tags:
     - RHEL-09-254035
     - CAT2
@@ -99,7 +109,9 @@
     value: '0'
 
 - name: "MEDIUM | RHEL-09-254040 | PATCH | RHEL 9 must not forward IPv6 source-routed packets by default"
-  when: rhel_09_254040
+  when:
+    - rhel_09_254040
+    - rhel9stig_system_uses_ipv6
   tags:
     - RHEL-09-254040
     - CAT2

--- a/tasks/Cat2/RHEL-09-254xxx.yml
+++ b/tasks/Cat2/RHEL-09-254xxx.yml
@@ -14,6 +14,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.accept_ra
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -32,6 +33,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.accept_redirects
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -50,6 +52,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.accept_source_route
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -69,6 +72,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.all.forwarding
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -87,6 +91,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.default.accept_ra
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -105,6 +110,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.default.accept_redirects
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'
@@ -123,6 +129,7 @@
     - NIST800-53R4_CM-6
   ansible.posix.sysctl:
     name: net.ipv6.conf.default.accept_source_route
+    state: present
     reload: true
     sysctl_file: "{{ rhel9stig_sysctl_file.network }}"
     value: '0'


### PR DESCRIPTION
**Overall Review of Changes:**
- Applied `rhel9stig_system_uses_ipv6` when conditional to all IPv6 sysct tasks
- Standardized usage of `ansible.posix.sysctl` module
- Removed unneeded Handler

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL9-STIG/issues/98

**Enhancements:**
When working the issue above noticed inconsistencies in how the `ansible.posix.sysctl`  was used across task files so I
- Standardized the usage of the `ansible.posix.sysctl` module
- Removed unneeded Handler

**How has this been tested?:**
1. Created blank RHEL 9.5 Minimal Server VM from template
#### From Remote Host
2. `git clone git@github.com:PrymalInstynct/RHEL9-STIG-MPG.git`
3. `pushd RHEL9-STIG-MPG`
4. `git checkout ipv6`
5. Create inventory.yml
6. `ansible-playbook -i inventory.yml site.yml -K`

```yaml
---
all:
  children:
    stig:
      hosts:
        10.10.1.211:
          ansible_ssh_common_args: '-o StrictHostKeyChecking=no'

```

