### PR TITLE
Added rhel9stig_sysctl_max_user_namespaces for systems that will run containers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -713,6 +713,8 @@ rhel9stig_sysctl_file:
   kernel: "{{ rhel9stig_sysctl_file_default }}"
   network: "{{ rhel9stig_sysctl_file_default }}"
   user: "{{ rhel9stig_sysctl_file_default }}"
+# Systems that run containers must set this value to greater then 0 for example: 65536
+rhel9stig_sysctl_max_user_namespaces: '0'
 
 ## Chrony
 rhel9stig_time_synchronization_servers:

--- a/tasks/Cat2/RHEL-09-213xxx.yml
+++ b/tasks/Cat2/RHEL-09-213xxx.yml
@@ -379,7 +379,7 @@
     state: present
     sysctl_file: "{{ rhel9stig_sysctl_file.user }}"
     sysctl_set: true
-    value: '0'
+    value: '{{ rhel9stig_sysctl_max_user_namespaces }}'
 
 - name: "MEDIUM | RHEL-09-213110 | PATCH | RHEL 9 must implement nonexecutable data to protect its memory from unauthorized code execution."
   when: rhel_09_213110


### PR DESCRIPTION
**Overall Review of Changes:**
Systems that run containers need access to create user namespaces. The STIG RHEL-09-213105 sets this sysctl value to 0 which will cause issues for those containers

**Issue Fixes:**
N/A

**Enhancements:**
- Added `rhel9stig_sysctl_max_user_namespaces` variable to `defaults\main.yml` enabling users to set this value to something appropriate for their system needs

**How has this been tested?:**
1. Created blank RHEL 9.5 Minimal Server VM from template
#### From Remote Host
2. `git clone git@github.com:PrymalInstynct/RHEL9-STIG-MPG.git`
3. `pushd RHEL9-STIG-MPG`
4. `git checkout container_namespace`
5. Create inventory.yml
6. `ansible-playbook -i inventory.yml site.yml -K --tag RHEL-09-213105`

```yaml
---
all:
  children:
    stig:
      hosts:
        10.10.1.211:
          ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
          rhel9stig_sysctl_max_user_namespaces: '65536'

```
