### PR TITLE
Use rhel9stig_gui_approved variable with tasks that make sense

### DIFF
--- a/tasks/Cat2/RHEL-09-211xxx.yml
+++ b/tasks/Cat2/RHEL-09-211xxx.yml
@@ -52,7 +52,9 @@
         - /etc/issue.net
 
 - name: "MEDIUM | RHEL-09-211030 | PATCH | The graphical display manager must not be the default target on RHEL 9 unless approved."
-  when: rhel_09_211030
+  when:
+    - rhel_09_211030
+    - not rhel9stig_gui_approved
   tags:
     - RHEL-09-211030
     - CAT2

--- a/tasks/Cat2/RHEL-09-215xxx.yml
+++ b/tasks/Cat2/RHEL-09-215xxx.yml
@@ -152,7 +152,9 @@
     state: absent
 
 - name: "MEDIUM | RHEL-09-215070 | PATCH | A graphical display manager must not be installed on RHEL 9 unless approved."
-  when: rhel_09_215070
+  when:
+    - rhel_09_215070
+    - not rhel9stig_gui_approved
   tags:
     - RHEL-09-215070
     - CAT2


### PR DESCRIPTION
**Overall Review of Changes:**
There is a variable `rhel9stig_gui_approved` in `defaults/main.yml` not being used. I added this variable as a contaitional check to `RHEL-09-211030` and `RHEL-09-215070` so that if a GUI it approved xorg will not be uninstalled and multi-user.target will not be overwritten.

**Issue Fixes:**
I did not write an issue, but if this variable is not used systems that have a GUI installed and approved for use will not function as expected after applying the STIG role

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
1. Created blank RHEL 9.5 Workstation VM from template
#### From Remote Host
2. `git clone git@github.com:PrymalInstynct/RHEL9-STIG-MPG.git`
3. `pushd RHEL9-STIG-MPG`
4. `git checkout gui-approved`
5. Create inventory.yml
6. `ansible-playbook -i inventory.yml site.yml -K`

```yaml
---
all:
  vars:
    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
    ansible_python_interpreter: auto_silent
    skip_reboot: false
  children:
    wks-stig:
      vars:
        rhel9stig_gui_approved: true
      hosts:
        10.10.1.220:
          ansible_hosts: wks-stig-test.local.domain

```

