### PR TITLE
Rename audit_bins var rhel9stig_audit_bins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -890,8 +890,9 @@ rhel9stig_audit_conf_space_left: 25%
 rhel9stig_audit_conf_space_left_action: email
 rhel9stig_audit_conf_write_logs: 'yes'
 rhel9stig_audit_backlog_limit: 8192
+
 # Audit binaries
-audit_bins:
+rhel9stig_audit_bins:
 - '/usr/sbin/auditctl'
 - '/usr/sbin/aureport'
 - '/usr/sbin/ausearch'


### PR DESCRIPTION
**Overall Review of Changes:**
Fixes regression in defaults/main.yml where audit_bins var should have been renamed to rhel9stig_audit_bins.

Originally renamed here https://github.com/ansible-lockdown/RHEL9-STIG/pull/97/files#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4R879

Possibly a merge conflict with earlier commit: https://github.com/ansible-lockdown/RHEL9-STIG/commit/3d99cbed1d0ae700d683430e7750127330bc40c8#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4R870-R875

**Issue Fixes:**
n/a

**Enhancements:**
n/a

**How has this been tested?:**
Manually

