### PR TITLE
2026 June QA: RHEL 9 STIG V2R7 Remediation QA pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Based on STIG V2R7 - 2026 May QA Final updates
 
-- aide.conf.j2 + RHEL-09-651xxx hardened for aide 0.18+ compatibility (addresses #161)
-- Thank you @hectoralicea for submitting issue #161
-- Thank you @uk-bolly for Private PR 32 review
+- RHEL-09-252050 PATCH configure postfix: removed quoted-string clause from the `when:` list at `tasks/Cat2/RHEL-09-252xxx.yml:159` and appended `.stdout` to the register access. The clause `"rhel9stig_postfix_client_conf not in discovered_postfix_client_restrict"` was a literal YAML string (truthy, but non-boolean); Ansible 2.19+ strict-conditional rejected it on the second converge, hard-failing the role. The first converge masked it because the parent `rhel9stig_disruption_high: false` gate short-circuited before the broken item was evaluated.
+- Audit bridge template (`templates/ansible_vars_goss.yml.j2`): removed doubled `RPM-GPG-KEY-RPM-GPG-KEY-` segment from `rpm_gpg_key` path (audit was asserting a non-existent file); merged duplicate `rhel9stig_dns_servers` key emitted under separate IPv4/IPv6 conditionals into a single key block (IPv6 silently overwrote IPv4 when both `rhel9stig_dns_ip4_servers` and `rhel9stig_dns_ip6_servers` were defined, hiding the IPv4 list from the audit role).
+- Renamed 6 AUDIT-named tasks that modified state to PATCH (read-only contract). Tasks named `| AUDIT |` must not invoke modifying modules; `--tags AUDIT` and `--check` runs were silently mutating state. Affected: RHEL-09-215105 "Add required pmod files" (template), RHEL-09-232045 "update permissions" (file with mode/owner), RHEL-09-251030 (lineinfile to /etc/firewalld/firewalld.conf), RHEL-09-411090 "no authselect" both password-auth and system-auth variants (lineinfile), RHEL-09-412035 "create file if absent" + "Edit file if present" (template + lineinfile). The 411090 password-auth task name suffix also disambiguated to "password-auth no authselect" so it no longer collides with the system-auth sibling.
+- `set -o pipefail` added to 25 single-line `ansible.builtin.shell:` tasks with piped commands across `tasks/prelim.yml` (10) and `tasks/Cat2/RHEL-09-{212,213,214,232}xxx.yml` (15). All converted to the multi-line block-scalar shell form matching the existing convention in `tasks/parse_etc_passwd.yml`, `tasks/pre_remediation_audit.yml`, and `tasks/post_remediation_audit.yml`. Without pipefail, early-pipeline failures (e.g. grep rc=2 from a missing file) were masked by the final command's rc=0 and the failed_when conditions never tripped, allowing silently corrupt registered variables.
+- PRELIM NetworkManager DNS state task: `failed_when:` accepts rc=2 (file absent) in addition to rc=0/1. Required follow-up to the `set -o pipefail` change because grep's rc=2 (NetworkManager.conf missing on minimal containers) now propagates through the pipeline instead of being masked by sed's rc=0. On systems without NetworkManager.conf the task now succeeds with an empty stdout, matching the pre-pipefail behavior.
+- `no_log: true` added to 4 tasks that handle shadow-file content or lock accounts: RHEL-09-411015 AUDIT (awk on /etc/shadow for pass-max-days), RHEL-09-611080 AUDIT (awk on /etc/shadow for 24-hour restriction), RHEL-09-671015 AUDIT (cat/grep on /etc/shadow for non-FIPS hashes), RHEL-09-611155 PATCH (`ansible.builtin.user password_lock` looping empty-password accounts). Prevents password hash leakage in verbose Ansible output and Ansible logs.
+- aide.conf.j2 + RHEL-09-651xxx hardened for aide 0.18+ compatibility (addresses ansible-lockdown/RHEL9-STIG#161)
+- molecule default scenario aligned with RHEL8-STIG sibling: enabled rhel9stig_disruption_high, fetch_audit_output, audit_output_destination; prepare.yml adds openssl-pkcs11 + opensc for PAM smartcard coverage
+- added molecule/README_Molecule_QuickStart.md - quick-start guide for the default scenario (venv, host_vars, expected results, gating-run command sequence)
+- Thank you @hectoralicea for submitting issue ansible-lockdown/RHEL9-STIG#161
+- Thank you @uk-bolly for the review
 - Lint
 - Alignment
 - dup control removed
@@ -32,8 +40,6 @@
 - molecule ubi prepare stubs /etc/audit, /etc/audit/rules.d, /etc/aide, /etc/aide/aide.conf.d since those packages are subscription-gated in public UBI repos
 - defaults/main.yml documentation improved - added WARNING block on variable precedence, richer comments for setup_audit/run_audit/get_audit_binary_method/audit_content/disruption_high, exposed change_requires_reboot
 - defaults/main.yml list vars indented with 2-space sequence style for consistency
-- devel_pipeline_validation.yml IAC_BRANCH if-else block normalized to 2-space indent (matches main_pipeline_validation.yml)
-- export_badges_private.yml dead conditional removed (referenced github.event_name == 'schedule' but no schedule trigger is defined)
 - tasks/main.yml connecting-user check: fixed undefined variable rhel10stig_playbook_user -> rhel9stig_playbook_user and stray trailing quote in task name
 - rsyslog remote-server var aligned end-to-end (defaults rhel9stig_rsyslog_remote_server_ip; legacy lineinfile, rainerscript template, and audit bridge updated to match)
 - tasks/prelim.yml authselect prelim task: replaced undefined dict ref rhel9stig_authselect['custom_profile_name'] with scalar rhel9stig_authselect_custom_profile; corrected duplicated STIG IDs in name (411080|411080|411090 -> 411080|411085|411090) and when condition (411085 or 411085 or 411090 -> 411080 or 411085 or 411090)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ ansible_facts_path: /etc/ansible/facts.d
 # This is useful when part of kickstart build or running as root and not defining the ansible_user option
 # used @ RHEL-09-411015
 rhel9stig_default_user: root
-rhel9stig_connecting_user: "{{ ansible_env.SUDO_USER | default(rhel9stig_default_user) }}"
+rhel9stig_connecting_user: "{{ ansible_facts['env']['SUDO_USER'] | default(rhel9stig_default_user) }}"
 rhel9stig_playbook_user: "{{ ansible_user | default(rhel9stig_connecting_user) }}"
 
 # Whether to skip the system reboot before audit
@@ -737,7 +737,7 @@ rhel9stig_dns_processing_mode: 'none'
 # rhel9stig_custom_firewall_zone is the desired name for the firewall zone
 rhel9stig_custom_firewall:
   zone: "drop"
-  interface: "{{ ansible_default_ipv4.interface }}"
+  interface: "{{ ansible_facts['default_ipv4']['interface'] }}"
 
 # rhel9stig_white_list_services is the services that you want to allow through initially for the new firewall zone
 # http and ssh need to be enabled for the role to run.
@@ -771,7 +771,7 @@ rhel9stig_allow_fapolicy_updates: false
 # rhel9stig_fapolicy_white_list is the whitelist for fapolicyd
 rhel9stig_fapolicy_white_list:
   - '# Allow Ansible'
-  - "allow perm=any trust=1 : dir={{ ansible_env.PWD }}/.ansible/"
+  - "allow perm=any trust=1 : dir={{ ansible_facts['env']['PWD'] }}/.ansible/"
   - 'allow perm=any trust=1 : dir=/root/.ansible/'
   - 'allow perm=any trust=1 : dir=/tmp/ansible/'
 

--- a/molecule/README_Molecule_QuickStart.md
+++ b/molecule/README_Molecule_QuickStart.md
@@ -1,0 +1,179 @@
+# Molecule Quick Start - RHEL9-STIG
+
+> Audience: anyone new to molecule testing with this Ansible Lockdown role. Read top-to-bottom the first time; come back to the reference tables later.
+
+## Two scenarios live here: `default/` vs `ubi/`
+
+This `molecule/` directory ships two scenarios. Pick the right one before running:
+
+| | `molecule/default/` (canonical) | `molecule/ubi/` (smoke test) |
+|---|---|---|
+| **When to use** | Every QA cycle, before merging/pushing. This is the **gating scenario**. | Occasional sanity check against Red Hat's upstream UBI image (e.g. confirm role still applies on the registry image, not just on the Rocky variant). |
+| **Container image** | `rockylinux/rockylinux:9-ubi-init` | `redhat/ubi9-init:latest` |
+| **Container name** | `rhel9-stig-qa` | `rhel9-stig-ubi` |
+| **`audit_git_version`** | tracked with the current benchmark branch (e.g. `benchmark_v2r7`) | may lag - check `molecule/ubi/molecule.yml` before running |
+| **`rhel9stig_disruption_high`** | `true` (exercises full code path) | `false` (conservative) |
+| **`fetch_audit_output`** | `true` (auto-copies audit JSONs out to `_temp_fetched_audits/`) | not set (audit results stay inside the container; `docker cp` them out manually) |
+| **`prepare.yml` package set** | Full (audit, aide, chrony, rsyslog, logrotate, cronie, acl, kmod, dnf-plugins-core, python3-libselinux, python3-policycoreutils, python3-dnf-plugin-versionlock, tmux, git, procps-ng, openssl-pkcs11, opensc) | Subset; some packages aren't in UBI repos so installs run with `ignore_errors: true` |
+| **Maintenance** | Kept in lock-step with the role and audit repos every cycle | Updated less often; intentionally drift-tolerant |
+
+**Rule of thumb:** if you don't know which to use, use `default/`. `ubi/` is for cases where you specifically want to validate against Red Hat's `redhat/ubi9-init` registry image rather than the Rocky variant.
+
+The rest of this document focuses on the `default/` scenario. To run the `ubi/` scenario instead, swap `molecule destroy` -> `molecule -s ubi destroy` (and the same `-s ubi` flag on `converge`, `verify`).
+
+## What this scenario does
+
+Molecule spins up a throwaway Rocky 9 Docker container, applies the **whole** Ansible Lockdown RHEL 9 STIG role against it, then runs the paired goss audit (from the `RHEL9-STIG-Audit` repo) to see how many controls passed and how many still fail. It's the gating test you run before merging or pushing benchmark changes.
+
+End-to-end you get:
+1. A clean container booted into systemd.
+2. Pre-remediation audit (baseline): records which controls are already failing before the role runs.
+3. Role converge #1: applies all the STIG remediations.
+4. Role converge #2: re-runs to confirm idempotency (zero changed tasks the second time).
+5. Post-remediation audit: records the after-picture.
+6. Pre and post audit JSON summaries automatically copied out to a directory beside the role for review.
+
+If steps 3 and 4 both report `failed=0` and step 6 shows the post-audit failure count substantially lower than the pre-audit count, the role is shippable.
+
+## Prerequisites
+
+| Need | Why | How to check |
+|---|---|---|
+| Docker (Desktop or Engine), running | Molecule uses Docker to create the test container | `docker info` returns without error |
+| Python 3.10+ | Ansible / Molecule are Python tools | `python3 --version` |
+| Ansible venv with `ansible-core >= 2.19`, `molecule`, `molecule-plugins[docker]`, `docker`, `passlib` | Runtime deps for the test | `pip list \| grep -E 'ansible|molecule'` |
+| `git` on the controller | Audit content is cloned from `RHEL9-STIG-Audit` | `git --version` |
+| Local clones of **both** `RHEL9-STIG` AND `RHEL9-STIG-Audit` (or network access so the audit repo can be cloned at runtime) | The role pulls audit goss content from the audit repo during converge | `git -C <path-to>/RHEL9-STIG-Audit status` |
+
+One-time venv setup (skip if you already have one):
+
+```bash
+python3 -m venv <path-to-your-ansible-venv>
+source <path-to-your-ansible-venv>/bin/activate
+pip install 'ansible-core>=2.19' 'molecule>=24' 'molecule-plugins[docker]' docker passlib
+```
+
+## Quick start
+
+```bash
+# Every time
+source <path-to-your-ansible-venv>/bin/activate
+cd <path-to>/RHEL9-STIG
+
+# Full gating pair
+molecule destroy && molecule converge && molecule converge && molecule verify
+```
+
+The whole sequence takes 15-25 minutes on a modern laptop. Network is needed (clone of audit content + dnf installs) for the first run; subsequent runs reuse the cached Docker image.
+
+## What each command does
+
+| Command | What happens |
+|---|---|
+| `molecule destroy` | Removes any leftover container from a previous run. Safe to run on a clean system. |
+| `molecule converge` (first) | (a) pulls / starts the `rockylinux/rockylinux:9-ubi-init` container, (b) runs `prepare.yml` to install supporting packages, (c) clones the audit content from `RHEL9-STIG-Audit`, (d) runs the pre-remediation audit, (e) applies the full role, (f) runs the post-remediation audit, (g) fetches both audit JSONs to your local `_temp_fetched_audits/` folder. |
+| `molecule converge` (second) | Re-runs the role against the already-remediated container. The Ansible `PLAY RECAP` should show `changed=0` (or a small handful of acceptable re-renders) - that's the **idempotency check**. |
+| `molecule verify` | Final assertions defined in the scenario (light by default for this role; the real validation is in the audit JSONs). |
+
+## Where the audit results land
+
+After `molecule converge` completes, look at:
+
+```
+<working-tree>/_temp_fetched_audits/
+  rhel9-stig-qa-RHEL9-STIG-v<ver>_pre_scan_<timestamp>.json
+  rhel9-stig-qa-RHEL9-STIG-v<ver>_post_scan_<timestamp>.json
+```
+
+The JSONs are goss output - each has a `results: []` array where every entry has a `successful: true|false` field. Compare pre vs. post:
+
+```bash
+# How many controls passed before remediation?
+jq '[.results[] | select(.successful==true)] | length' <pre_scan>.json
+
+# How many passed after?
+jq '[.results[] | select(.successful==true)] | length' <post_scan>.json
+```
+
+If the second number is significantly higher than the first, the role is working as intended.
+
+## How to read `PLAY RECAP`
+
+After each converge, Ansible prints a one-line summary like:
+
+```
+PLAY RECAP ********************************************************
+rhel9-stig-qa : ok=238  changed=73  unreachable=0  failed=0  skipped=547  rescued=0  ignored=0
+```
+
+| Counter | What it means |
+|---|---|
+| `ok` | Tasks that ran and finished successfully (no state change needed, or already in desired state) |
+| `changed` | Tasks that modified the system (installed a package, edited a file, etc.) |
+| `failed` | Tasks that errored out. **MUST BE 0** for the run to be considered passing. |
+| `skipped` | Tasks gated off by `when:` conditions (often because `system_is_container: true` skips container-incompatible work) |
+| `rescued` / `ignored` | Block-level error handling - typically 0 |
+
+**Idempotency expectation:** the second `converge` should show `changed=0` (or near zero) - the system was already in the desired state. A high `changed` count on the second run means a task is not idempotent and needs fixing.
+
+## Why some audit failures are expected (even after the role passes)
+
+The post-scan will still show some controls failing. Most fall into three buckets that aren't role bugs - they're inherent to containerized testing:
+
+1. **SSH-config controls** (banner, ciphers, KexAlgorithms, MACs, idle timeouts, login grace time): these check `/etc/ssh/sshd_config`, which doesn't exist because `openssh-server` is intentionally NOT installed (running sshd inside Docker is an anti-pattern; containers use `docker exec` for shell access). The role's `when: rhel9stig_ssh_required` gate handles this correctly on real hosts.
+
+2. **User-state controls** (FIPS-hashed passwords, password lifetime, dotfile audit): need real interactive users (UID >= 1000) with shadow entries and home directories. Containers only have system accounts (`chrony`, `polkitd`, `tss`, etc.), so the controls can't satisfy their preconditions.
+
+3. **Kernel / mount controls**: any control gated by `not system_is_container` is intentionally skipped during remediation (auditd, FIPS, kernel sysctls, mount options) because containers share the host kernel. Audit still runs the goss tests, so they report as failing.
+
+None of these warrant fixing the role. They're the expected delta between a containerized test and a real RHEL 9 host.
+
+## Common gotchas
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `molecule converge` errors with "container not running" | Stale container from a previous interrupted run | Run `molecule destroy` first, then retry |
+| Pre-task fails with "Failed to download metadata" | UBI image can't reach Red Hat repos, or no network | Check Docker network; some packages may be unavailable in UBI - that's expected (see `ignore_errors` in `prepare.yml`) |
+| Converge #2 fails on a task that passed in #1 | Ansible 2.19+ struct-vs-string type-check tripping a `when:` clause that's "lucky" on the first run | Inspect the offending task's `when:` - look for quoted-string-as-boolean bugs |
+| `Conditional result (True) was derived from value of type 'str'` | Ansible 2.19+ rejects when-clauses whose final value is a non-boolean string. Common bug: an `or "<some expression>"` where the RHS got wrapped in quotes by accident | Remove the quotes; the RHS should be a bare Jinja expression |
+| `verify` step empty / passes trivially | Expected - this role's primary validation is the goss audit JSONs, not molecule's `verifier:` plays | Inspect the audit JSONs instead |
+
+## Why no Ansible pinning is needed (opposite of RHEL 8)
+
+RHEL 9 / Rocky 9 ship Python 3.9 by default with full `dnf` Python bindings, so Ansible 2.19+ runs cleanly on managed nodes. RHEL 8's pinning constraint (platform-python 3.6 with dnf bindings vs. Python 3.9/3.11 without dnf bindings) does not apply here - use any current Ansible venv.
+
+## Reference: what's in the default scenario
+
+| File | Purpose |
+|---|---|
+| `molecule.yml` | Driver: docker. Image: `rockylinux/rockylinux:9-ubi-init` on `linux/arm64` (multi-arch image; native on Apple Silicon and amd64). Host vars listed in the next table. |
+| `prepare.yml` | Bootstraps minimal Rocky 9 UBI via `raw` (python3, sudo, iproute, openssh), then installs supporting packages (`audit`, `aide`, `crypto-policies`, `firewalld`, `chrony`, `rsyslog`, `logrotate`, `cronie`, `acl`, `kmod`, `dnf-plugins-core`, `python3-libselinux`, `python3-policycoreutils`, `python3-dnf-plugin-versionlock`, `tmux`, `git`, `procps-ng`, `openssl-pkcs11`, `opensc`). Stubs `/etc/default/grub` so GRUB-tag tasks don't fail in the container. |
+| `converge.yml` | Sets root password (so PAM tasks don't lock us out), includes the role. |
+
+## Reference: host vars (in `molecule/default/molecule.yml`)
+
+| Override | Default | Purpose |
+|---|---|---|
+| `audit_git_version` | current `benchmark_<vNrM>` branch | Branch on `RHEL9-STIG-Audit` to pull goss content from. Override to test a QA branch before merging (see "Overriding the audit branch" below). |
+| `audit_output_destination` | `<working_dir>/_temp_fetched_audits/` (relative to `MOLECULE_PROJECT_DIRECTORY`) | Where fetched audit JSONs land. Pinned outside the role tree so they don't pollute system paths or git. |
+| `rhel9stig_disruption_high` | `true` (molecule default) | Exercises high-disruption code paths (account locks, password lifetime resets, fapolicyd rules, sysctl reloads). Safe in throwaway containers; risky on real hosts. Defaults to `false` in `defaults/main.yml` for production safety. |
+| `fetch_audit_output` | `true` | Auto-copies audit JSONs out of the container to `audit_output_destination`. |
+| `system_is_container` | `true` | Gates container-incompatible tasks (auditd, FIPS, kernel sysctls, mount changes, GRUB, etc.) - see `vars/is_container.yml`. |
+| `skip_reboot` | `true` | Suppresses reboot handlers (containers can't reboot). |
+
+## Overriding the audit branch
+
+If you're QA'ing a feature branch on `RHEL9-STIG-Audit` that hasn't been merged yet, override via extra-vars:
+
+```bash
+molecule converge -- --extra-vars 'audit_git_version=<your-qa-branch>'
+```
+
+`include_vars` has higher precedence than play/host vars in Ansible, so `--extra-vars` is the only way to change the audit branch from a Lockdown-internal `vars/audit.yml` pin.
+
+## Where to ask for help
+
+- This role's open issues: `github.com/ansible-lockdown/RHEL9-STIG/issues`
+- Ansible Lockdown Discord (linked from the role README badge)
+- Molecule docs: `molecule.readthedocs.io`
+- Goss output format: `github.com/goss-org/goss`

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,7 +9,10 @@
     audit_git_version: benchmark_v2r7
     system_is_container: true
     skip_reboot: true
-    rhel9stig_disruption_high: false
+    # Molecule default - overrides role default (`false`) to exercise full code path
+    rhel9stig_disruption_high: true
+    fetch_audit_output: true
+    audit_output_destination: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../_temp_fetched_audits/"
   pre_tasks:
     - name: Set root password so PAM rules don't lock us out
       ansible.builtin.user:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -35,6 +35,13 @@ provisioner:
         audit_git_version: benchmark_v2r7
         skip_reboot: true
         system_is_container: true
-        rhel9stig_disruption_high: false
+        # Override role default (`false` in defaults/main.yml) - safe in this
+        # throwaway container, exercises the full disruption_high code paths.
+        rhel9stig_disruption_high: true
+        fetch_audit_output: true
+        # Files land one level above the role repo (working dir root), e.g.
+        # `<working_dir>/_temp_fetched_audits/`. Override with `-e audit_output_destination=...`
+        # if you want them somewhere else.
+        audit_output_destination: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../_temp_fetched_audits/"
 verifier:
   name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -36,6 +36,8 @@
           - tmux
           - git
           - procps-ng
+          - openssl-pkcs11
+          - opensc
         state: present
 
     - name: Create directories that minimal images lack

--- a/tasks/Cat1/RHEL-09-6xxxxx.yml
+++ b/tasks/Cat1/RHEL-09-6xxxxx.yml
@@ -24,7 +24,7 @@
 - name: HIGH | RHEL-09-671010 | PATCH | RHEL 9 must enable FIPS mode.
   when:
     - rhel_09_671010
-    - not ansible_fips
+    - not ansible_facts['fips']
   tags:
     - RHEL-09-671010
     - CAT1

--- a/tasks/Cat2/RHEL-09-212xxx.yml
+++ b/tasks/Cat2/RHEL-09-212xxx.yml
@@ -56,7 +56,9 @@
     - NIST800-53R4_CM-6
   block:
     - name: "MEDIUM | RHEL-09-212015 | AUDIT | RHEL 9 must disable the ability of systemd to spawn an interactive boot process."
-      ansible.builtin.shell: grubby --info=ALL | grep args | grep 'systemd.confirm_spawn'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grubby --info=ALL | grep args | grep 'systemd.confirm_spawn'
       changed_when: false
       failed_when: discovered_systemd_spawn.rc not in [ 0, 1 ]
       register: discovered_systemd_spawn
@@ -116,7 +118,9 @@
     - NIST800-SC-3
   block:
     - name: "MEDIUM | RHEL-09-212035 | AUDIT | RHEL 9 must disable virtual system calls. | Capture grubby"
-      ansible.builtin.shell: grubby --info=ALL | grep args | grep 'vsyscall=none'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grubby --info=ALL | grep args | grep 'vsyscall=none'
       changed_when: false
       failed_when: discovered_grubby_vsyscall.rc not in [ 0, 1 ]
       register: discovered_grubby_vsyscall
@@ -127,7 +131,9 @@
       changed_when: true
 
     - name: "MEDIUM | RHEL-09-212035 | AUDIT | RHEL 9 must disable virtual system calls. | Capture default grub"
-      ansible.builtin.shell: grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"' | grep vsyscall
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"' | grep vsyscall
       changed_when: false
       failed_when: discovered_def_grub_vsyscall.rc not in [ 0, 1 ]
       register: discovered_def_grub_vsyscall
@@ -154,7 +160,9 @@
     - NIST800-53R4_SC-3
   block:
     - name: "MEDIUM | RHEL-09-212040 | AUDIT | RHEL 9 must clear the page allocator to prevent use-after-free attacks. | Capture grubby"
-      ansible.builtin.shell: grubby --info=ALL | grep args | grep 'page_poison=1'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grubby --info=ALL | grep args | grep 'page_poison=1'
       changed_when: false
       failed_when: discovered_grubby_page_alloc.rc not in [ 0, 1 ]
       register: discovered_grubby_page_alloc
@@ -165,7 +173,9 @@
       changed_when: true
 
     - name: "MEDIUM | RHEL-09-212040 | AUDIT | RHEL 9 must clear the page allocator to prevent use-after-free attacks. | Capture default grub"
-      ansible.builtin.shell: grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"' | grep page_poison
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"' | grep page_poison
       changed_when: false
       failed_when: discovered_def_grub_poison.rc not in [ 0 ,1 ]
       register: discovered_def_grub_poison
@@ -194,7 +204,9 @@
     - NIST800-53R4_SI-16
   block:
     - name: "MEDIUM | RHEL-09-212045 | AUDIT | RHEL 9 must clear memory when it is freed to prevent use-after-free attacks. | Capture grubby"
-      ansible.builtin.shell: grubby --info=ALL | grep args | grep 'init_on_free=1'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grubby --info=ALL | grep args | grep 'init_on_free=1'
       changed_when: false
       failed_when: discovered_grubby_slab.rc not in [ 0, 1 ]
       register: discovered_grubby_slab

--- a/tasks/Cat2/RHEL-09-213xxx.yml
+++ b/tasks/Cat2/RHEL-09-213xxx.yml
@@ -401,7 +401,9 @@
     - NIST800-53R4_SI-16
   block:
     - name: "MEDIUM | RHEL-09-213110 | AUDIT | RHEL 9 must implement nonexecutable data to protect its memory from unauthorized code execution."
-      ansible.builtin.shell: dmesg | grep '[NX|DX]*protection'
+      ansible.builtin.shell: |
+        set -o pipefail
+        dmesg | grep '[NX|DX]*protection'
       changed_when: false
       failed_when: discovered_nxdx.rc not in [ 0, 1 ]
       register: discovered_nxdx

--- a/tasks/Cat2/RHEL-09-214xxx.yml
+++ b/tasks/Cat2/RHEL-09-214xxx.yml
@@ -12,14 +12,18 @@
     - NIST800-53R4_CM-5
   block:
     - name: "MEDIUM | RHEL-09-214010 | AUDIT | RHEL 9 must ensure cryptographic verification of vendor software packages. | find keys"
-      ansible.builtin.shell: "rpm -qa | grep {{ os_gpg_key_pubkey_name }}"  # noqa: command-instead-of-module
+      ansible.builtin.shell: |
+        set -o pipefail
+        rpm -qa | grep {{ os_gpg_key_pubkey_name }}  # noqa: command-instead-of-module
       changed_when: false
       failed_when: false
       register: discovered_os_installed_pub_keys
 
     - name: "MEDIUM | RHEL-09-214010 | AUDIT | RHEL 9 must ensure cryptographic verification of vendor software packages. | query keys"
       when: discovered_os_installed_pub_keys.rc == 0
-      ansible.builtin.shell: 'rpm -q --queryformat "%{PACKAGER} %{VERSION}\\n" {{ os_gpg_key_pubkey_name }} | grep "{{ os_gpg_key_pubkey_content }}"'  # noqa: command-instead-of-module
+      ansible.builtin.shell: |
+        set -o pipefail
+        rpm -q --queryformat "%{PACKAGER} %{VERSION}\\n" {{ os_gpg_key_pubkey_name }} | grep "{{ os_gpg_key_pubkey_content }}"  # noqa: command-instead-of-module
       changed_when: false
       failed_when: false
       register: discovered_os_gpg_key_check
@@ -54,7 +58,9 @@
     - NIST800-53R4_CM-6
   block:
     - name: "MEDIUM | RHEL-09-214030 | AUDIT | RHEL 9 must be configured so that the cryptographic hashes of system files match vendor values."
-      ansible.builtin.shell: rpm -Va --noconfig | awk '$1 ~ /..5/ && $2 != "c"'  # noqa: command-instead-of-module
+      ansible.builtin.shell: |
+        set -o pipefail
+        rpm -Va --noconfig | awk '$1 ~ /..5/ && $2 != "c"'  # noqa: command-instead-of-module
       changed_when: false
       failed_when: discovered_rpm_file_hash.rc not in [ 0, 1 ]
       register: discovered_rpm_file_hash

--- a/tasks/Cat2/RHEL-09-215xxx.yml
+++ b/tasks/Cat2/RHEL-09-215xxx.yml
@@ -321,7 +321,7 @@
       failed_when: discovered_crypto_policies_check.rc not in [0 , 1]
       register: discovered_crypto_policies_check
 
-    - name: "MEDIUM | RHEL-09-215105 | AUDIT | RHEL 9 must implement a FIPS 140-3 compliant systemwide cryptographic policy | Add required pmod files"
+    - name: "MEDIUM | RHEL-09-215105 | PATCH | RHEL 9 must implement a FIPS 140-3 compliant systemwide cryptographic policy | Add required pmod files"
       when: rhel9stig_disruption_high
       ansible.builtin.template:
         src: "{{ item }}.j2"

--- a/tasks/Cat2/RHEL-09-232xxx.yml
+++ b/tasks/Cat2/RHEL-09-232xxx.yml
@@ -14,7 +14,9 @@
     - NIST800-53R4_CM-5
   block:
     - name: "MEDIUM | RHEL-09-232010 | AUDIT | RHEL 9 system commands must have mode 755 or less permissive."
-      ansible.builtin.shell: find -L /bin /sbin /usr/bin /usr/sbin /usr/libexec /usr/local/bin /usr/local/sbin -perm /022 -type f -exec ls -l {} \; | awk '{ print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        find -L /bin /sbin /usr/bin /usr/sbin /usr/libexec /usr/local/bin /usr/local/sbin -perm /022 -type f -exec ls -l {} \; | awk '{ print $NF}'
       changed_when: false
       failed_when: discovered_system_command_permissions.rc not in [ 0, 1 ]
       register: discovered_system_command_permissions
@@ -40,7 +42,9 @@
     - NIST800-53R4_CM-5
   block:
     - name: "MEDIUM | RHEL-09-232015 | AUDIT | RHEL 9 library directories must have mode 755 or less permissive."
-      ansible.builtin.shell: find -L /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type d -exec ls -l {} \; | awk '{ print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        find -L /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type d -exec ls -l {} \; | awk '{ print $NF}'
       changed_when: false
       failed_when: discovered_library_directory_perms.rc not in [ 0, 1 ]
       register: discovered_library_directory_perms
@@ -65,7 +69,9 @@
     - NIST800-53R4_CM-5
   block:
     - name: "MEDIUM | RHEL-09-232020 | AUDIT | RHEL 9 library files must have mode 755 or less permissive."
-      ansible.builtin.shell: find -L /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type f -exec ls -l {} \; | awk '{ print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        find -L /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type f -exec ls -l {} \; | awk '{ print $NF}'
       changed_when: false
       failed_when: discovered_library_file_perms.rc not in [ 0, 1 ]
       register: discovered_library_file_perms
@@ -195,7 +201,7 @@
         recurse: true
       register: discovered_user_dot_files
 
-    - name: "MEDIUM | RHEL-09-232045 | AUDIT | All RHEL 9 local initialization files must have mode 0740 or less permissive. | update permissions"
+    - name: "MEDIUM | RHEL-09-232045 | PATCH | All RHEL 9 local initialization files must have mode 0740 or less permissive. | update permissions"
       ansible.builtin.file:
         path: "{{ item.path }}"
         mode: 'g-wx,o-rwx'
@@ -951,7 +957,9 @@
     - NIST800-53R4_SC-4
   block:
     - name: "MEDIUM | RHEL-09-232240 | AUDIT | All RHEL 9 world-writable directories must be owned by root, sys, bin, or an application user."
-      ansible.builtin.shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -uid +999
+      ansible.builtin.shell: |
+        set -o pipefail
+        df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -uid +999
       changed_when: false
       failed_when: discovered_worldwide_dir_owners.rc not in [ 0, 1 ]
       register: discovered_worldwide_dir_owners
@@ -984,7 +992,9 @@
     - NIST800-53R4_SC-4
   block:
     - name: "MEDIUM | RHEL-09-232245 | AUDIT | A sticky bit must be set on all RHEL 9 public directories."
-      ansible.builtin.shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -a ! -perm -1000 2>/dev/null
+      ansible.builtin.shell: |
+        set -o pipefail
+        df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -a ! -perm -1000 2>/dev/null
       changed_when: false
       failed_when: discovered_public_dirs_stickybit.rc not in [ 0, 1 ]
       register: discovered_public_dirs_stickybit

--- a/tasks/Cat2/RHEL-09-251xxx.yml
+++ b/tasks/Cat2/RHEL-09-251xxx.yml
@@ -103,7 +103,7 @@
       ansible.builtin.command: firewall-cmd --reload
       changed_when: true
 
-- name: "MEDIUM | RHEL-09-251030 | AUDIT |  RHEL 9 must protect against or limit the effects of denial-of-service (DoS) attacks by ensuring rate-limiting measures on impacted network interfaces are implemented."
+- name: "MEDIUM | RHEL-09-251030 | PATCH | RHEL 9 must protect against or limit the effects of denial-of-service (DoS) attacks by ensuring rate-limiting measures on impacted network interfaces are implemented."
   when: rhel_09_251030
   tags:
     - RHEL-09-251030
@@ -140,7 +140,7 @@
       when: discovered_ppsm_clsa_zone_config.stdout_lines is defined
       ansible.builtin.debug:
         msg:
-          - "The following output is what firewalld is configured for {{ ansible_hostname }}."
+          - "The following output is what firewalld is configured for {{ ansible_facts['hostname'] }}."
           - "{{ discovered_ppsm_clsa_zone_config.stdout_lines }}"
       changed_when: true
 

--- a/tasks/Cat2/RHEL-09-252xxx.yml
+++ b/tasks/Cat2/RHEL-09-252xxx.yml
@@ -97,7 +97,7 @@
         - prelim_network_manager_dns.stdout != 'unmanaged'
       notify: Restart_NetworkManager
       community.general.nmcli:
-        conn_name: "{{ ansible_default_ipv4.interface }}"
+        conn_name: "{{ ansible_facts['default_ipv4']['interface'] }}"
         type: ethernet
         dns4:
           - "{{ rhel9stig_dns_ip4_servers }}"
@@ -156,7 +156,7 @@
     - name: "MEDIUM | RHEL-09-252050 | PATCH | RHEL 9 must be configured to prevent unrestricted mail relaying. | configure postfix"
       when:
         - rhel9stig_disruption_high
-        - discovered_postfix_client_restrict.stdout | length == 0 or "rhel9stig_postfix_client_conf not in discovered_postfix_client_restrict"
+        - discovered_postfix_client_restrict.stdout | length == 0 or rhel9stig_postfix_client_conf not in discovered_postfix_client_restrict.stdout
       ansible.builtin.command: "postconf -e 'smtpd_client_restrictions = {{ rhel9stig_postfix_client_conf }}'"
       changed_when: true
 

--- a/tasks/Cat2/RHEL-09-411xxx.yml
+++ b/tasks/Cat2/RHEL-09-411xxx.yml
@@ -30,6 +30,7 @@
       ansible.builtin.command: "awk -F: '$1 !~ /^root$/ && $2 !~ /^[!*]/ && $5 > {{ rhel9stig_pass_max_days }} {print $1}' /etc/shadow"
       changed_when: false
       failed_when: discovered_users_passwd_max.rc not in [ 0, 1 ]
+      no_log: true
       register: discovered_users_passwd_max
 
     - name: "MEDIUM | RHEL-09-411015 | PATCH | RHEL 9 user account passwords must have a 60-day maximum password lifetime restriction."
@@ -449,7 +450,7 @@
         line: "unlock_time = 0"
         mode: 'go-wx'
 
-    - name: "MEDIUM | RHEL-09-411090 | AUDIT | RHEL 9 must maintain an account lock until the locked account is released by an administrator. | not auth select profile"
+    - name: "MEDIUM | RHEL-09-411090 | PATCH | RHEL 9 must maintain an account lock until the locked account is released by an administrator. | password-auth no authselect"
       ansible.builtin.lineinfile:
         path: "/etc/pam.d/password-auth"
         regexp: "{{ item.regexp }}"

--- a/tasks/Cat2/RHEL-09-412xxx.yml
+++ b/tasks/Cat2/RHEL-09-412xxx.yml
@@ -19,7 +19,7 @@
         path: /etc/profile.d/tmout.sh
       register: discovered_timeout_script
 
-    - name: "MEDIUM | RHEL-09-412035 | AUDIT | RHEL 9 must automatically exit interactive command shell user sessions after 10 minutes of inactivity. | create file if absent"
+    - name: "MEDIUM | RHEL-09-412035 | PATCH | RHEL 9 must automatically exit interactive command shell user sessions after 10 minutes of inactivity. | create file if absent"
       when: not discovered_timeout_script.stat.exists
       ansible.builtin.template:
         src: etc/profile.d/tmout.sh.j2
@@ -28,7 +28,7 @@
         owner: root
         mode: 'u+x,go-w,go+x'
 
-    - name: "MEDIUM | RHEL-09-412035 | AUDIT | RHEL 9 must automatically exit interactive command shell user sessions after 10 minutes of inactivity. | Edit file if present"
+    - name: "MEDIUM | RHEL-09-412035 | PATCH | RHEL 9 must automatically exit interactive command shell user sessions after 10 minutes of inactivity. | Edit file if present"
       when: discovered_timeout_script.stat.exists
       ansible.builtin.lineinfile:
         path: /etc/profile.d/tmout.sh

--- a/tasks/Cat2/RHEL-09-611xxx.yml
+++ b/tasks/Cat2/RHEL-09-611xxx.yml
@@ -377,6 +377,7 @@
       ansible.builtin.command: "awk -F: '$4 < 1 {print $1}' /etc/shadow"
       changed_when: false
       failed_when: discovered_24hr_passwd_restrict.rc not in [ 0, 1 ]
+      no_log: true
       register: discovered_24hr_passwd_restrict
 
     - name: "MEDIUM | RHEL-09-611080 | WARN | RHEL 9 passwords must have a 24 hours minimum password lifetime restriction in /etc/shadow. | Warning"
@@ -687,6 +688,7 @@
         name: "{{ item }}"
         password_lock: true
       loop: "{{ prelim_empty_password_accounts.stdout_lines }}"
+      no_log: true
 
 # Prerequisite for 611160-611160
 - name: "MEDIUM | RHEL-09-611185 | PATCH | RHEL 9 must have the opensc package installed."

--- a/tasks/Cat2/RHEL-09-671xxx.yml
+++ b/tasks/Cat2/RHEL-09-671xxx.yml
@@ -20,6 +20,7 @@
       ansible.builtin.shell: 'cat /etc/shadow | grep -v "*" | grep -v "!" | grep -v ":$6$" | cut -f1 -d:'
       changed_when: false
       failed_when: false
+      no_log: true
       register: discovered_non_fips_hashed_accounts
 
     - name: "MEDIUM | RHEL-09-671015 | PATCH | RHEL 9 must employ FIPS 140-3 approved cryptographic hashing algorithms for all stored passwords. | Lock user not using FIPS 140-3 hashing"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,9 @@
   when: not skip_os_check
   tags: always
   ansible.builtin.assert:
-    that: (ansible_distribution != 'CentOS' and ansible_os_family == 'RedHat' or ansible_os_family == "Rocky") and ansible_distribution_major_version is version_compare('9',
-      '==')
-    fail_msg: This role can only be run against RHEL/Rocky 9 families. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported.
-    success_msg: This role is running against a supported OS {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }}
+    that: ( ansible_facts['distribution'] != 'CentOS' and ansible_facts['os_family'] == 'RedHat' or ansible_facts['os_family'] == "Rocky" ) and ansible_facts['distribution_major_version'] is version_compare('9', '==')
+    fail_msg: This role can only be run against RHEL/Rocky 9 families. {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }} is not supported.
+    success_msg: This role is running against a supported OS {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }}
 
 - name: Check ansible version
   tags: always
@@ -19,7 +18,7 @@
 - name: Setup rules if container
   when:
     - ansible_connection in ['docker', 'community.docker.docker'] or
-      ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+      ansible_facts['virtualization_type'] in ['docker', 'lxc', 'openvz', 'podman', 'container']
   tags:
     - container_discovery
     - always
@@ -39,7 +38,7 @@
 
 - name: Check password set for connecting user
   when:
-    - ansible_env.SUDO_USER is defined
+    - ansible_facts['env']['SUDO_USER'] is defined
     - not system_is_ec2
     - not audit_only
   block:
@@ -54,7 +53,7 @@
     - name: Assert that password set for {{ rhel9stig_playbook_user }} and account not locked  # noqa:name[template]
       tags: user_passwd
       ansible.builtin.assert:
-        that: discovered_rhel9stig_playbook_user_password_set.stdout | length != 0 and discovered_rhel9stig_playbook_user_password_set.stdout != "!!"
+        that: discovered_ansible_user_password_set.stdout | length != 0 and discovered_ansible_user_password_set.stdout != "!!"
         fail_msg: You have {{ sudo_password_rule }} enabled but the user = {{ rhel9stig_playbook_user }} has no password set - It can break access
         success_msg: You have a password set for the connecting user {{ rhel9stig_playbook_user }}
       vars:
@@ -63,7 +62,7 @@
 - name: Include OS specific variables
   tags: always
   ansible.builtin.include_vars:
-    file: "{{ ansible_distribution }}.yml"
+    file: "{{ ansible_facts['distribution'] }}.yml"
 
 - name: Check rhel9stig_bootloader_password_hash variable has been changed
   tags: grub

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -6,12 +6,16 @@
   tags: always
   block:
     - name: PRELIM | Capture UID_MIN information from logins.def
-      ansible.builtin.shell: grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
       changed_when: false
       register: prelim_uid_min_id
 
     - name: PRELIM | Capture UID_MAX information from logins.def
-      ansible.builtin.shell: grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
       changed_when: false
       register: prelim_uid_max_id
 
@@ -27,7 +31,9 @@
 
 - name: PRELIM | Interactive Users
   tags: always
-  ansible.builtin.shell: "grep -Ev 'nologin|/sbin' /etc/passwd | awk -F: '$3 >= {{ min_int_uid }} {print $1}'"
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep -Ev 'nologin|/sbin' /etc/passwd | awk -F: '$3 >= {{ min_int_uid }} {print $1}'
   changed_when: false
   register: prelim_interactive_users
 
@@ -47,7 +53,9 @@
 
 - name: PRELIM | Interactive User account home
   tags: always
-  ansible.builtin.shell: 'cat /etc/passwd | grep -Ev "nologin|/sbin" | cut -d: -f6'
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat /etc/passwd | grep -Ev "nologin|/sbin" | cut -d: -f6
   changed_when: false
   register: prelim_interactive_users_home
 
@@ -60,7 +68,9 @@
 - name: PRELIM | Gather accounts with empty password fields
   when: rhel_09_611155
   tags: passwords
-  ansible.builtin.shell: "cat /etc/shadow | awk -F: '($2 == \"\" ) {j++;print $1; } END {exit j}'"
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat /etc/shadow | awk -F: '($2 == "" ) {j++;print $1; } END {exit j}'
   changed_when: false
   failed_when: prelim_empty_password_accounts.rc not in [ 0, 1 ]
   no_log: true
@@ -71,7 +81,9 @@
     - level1-server
     - level1-workstation
     - users
-  ansible.builtin.shell: "cat /etc/passwd | awk -F: '($3 == 0 && $1 != \"root\") {i++;print $1 } END {exit i}'"
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat /etc/passwd | awk -F: '($3 == 0 && $1 != "root") {i++;print $1 } END {exit i}'
   changed_when: false
   check_mode: false
   register: prelim_uid_zero_accounts_except_root
@@ -79,7 +91,7 @@
 - name: PRELIM | Create list of mount points
   tags: always
   ansible.builtin.set_fact:
-    mount_names: "{{ ansible_mounts | map(attribute='mount') | list }}"
+    mount_names: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"
 
 - name: PRELIM | Ensure python3-libselinux is installed
   when:
@@ -152,7 +164,9 @@
       rhel_09_653085 or
       rhel_09_653090
   tags: always
-  ansible.builtin.shell: grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
   changed_when: false
   register: discovered_auditd_logfile
 
@@ -204,9 +218,11 @@
 - name: "PRELIM | Capture NetworkManager DNS state"
   when: rhel_09_252035 or rhel_09_252040
   tags: always
-  ansible.builtin.shell: grep -E "dns\s*=" /etc/NetworkManager/NetworkManager.conf | cut -d = -f2 | sed s/" "//g
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep -E "dns\s*=" /etc/NetworkManager/NetworkManager.conf | cut -d = -f2 | sed s/" "//g
   changed_when: false
-  failed_when: prelim_network_manager_dns.rc not in [ 0, 1 ]
+  failed_when: prelim_network_manager_dns.rc not in [ 0, 1, 2 ]
   register: prelim_network_manager_dns
 
 - name: PRELIM | Discover Gnome Desktop Environment
@@ -217,7 +233,9 @@
 
 - name: PRELIM | Discover dconf systemdb
   when: rhel9stig_gui
-  ansible.builtin.shell: grep system-db /etc/dconf/profile/user | cut -d ':' -f2
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep system-db /etc/dconf/profile/user | cut -d ':' -f2
   changed_when: false
   failed_when: prelim_dconf_db.rc not in [ 0, 1 ]
   register: prelim_dconf_db
@@ -264,7 +282,9 @@
   tags: always
   block:
     - name: "PRELIM | Setup authselect if setting allow"
-      ansible.builtin.shell: "authselect current | grep with-faillock"
+      ansible.builtin.shell: |
+        set -o pipefail
+        authselect current | grep with-faillock
       failed_when: false
       changed_when: false
       check_mode: false

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -19,7 +19,7 @@ rhel9stig_os_distribution: {{ ansible_facts.distribution | lower }}
 
 {% if ansible_facts.distribution == "RedHat" %}
 # RHEL
-rpm_gpg_key: /etc/pki/rpm-gpg/RPM-GPG-KEY-RPM-GPG-KEY-redhat-release
+rpm_gpg_key: /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpg_key:
   - name: 'release key 2'
     fingerprint: '567E 347A D004 4ADE 55BA  8A5F 199E 2F91 FD43 1D51'
@@ -610,14 +610,13 @@ rhel9stig_time_synchronization_servers:
 rhel9stig_chrony_server_options: "{{ rhel9stig_chrony_server_options }}"  # Max Setting is maxpoll 16
 
 # DNS
-{% if rhel9stig_dns_ip4_servers is defined %}
 rhel9stig_dns_servers:
+{% if rhel9stig_dns_ip4_servers is defined %}
 {% for server in rhel9stig_dns_ip4_servers %}
   - nameserver {{ server }}
 {% endfor %}
 {% endif %}
 {% if rhel9stig_dns_ip6_servers is defined %}
-rhel9stig_dns_servers:
 {% for server in rhel9stig_dns_ip6_servers %}
   - nameserver {{ server }}
 {% endfor %}


### PR DESCRIPTION
**Overall Review of Changes:**
QA hardening pass on top of the aide 0.18 hotfix branch:
- AUDIT-named tasks that modified state renamed to PATCH (read-only contract)
- set -o pipefail added to 25 piped shell tasks; prelim DNS failed_when accepts rc=2
- no_log: true on 4 tasks reading /etc/shadow or locking accounts
- RHEL-09-252050 when: conditional fixed for Ansible 2.19+ strict-conditional
- audit bridge template: doubled RPM-GPG-KEY segment removed, DNS key block merged
- RHEL-09-214025 find/replace, 611195/611200 idempotency, 271065 dconf format fixes
- molecule default + ubi scenarios aligned with QuickStart README added

**How has this been tested?:**
Molecule
