### PR TITLE
fix: correct dconf and remediation task defects

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -72,7 +72,7 @@
 
 - name: "Get authselect faillock state"
   when: not rhel9stig_add_faillock_without_authselect
-  ansible.builtin.command: authselect current | grep failock
+  ansible.builtin.command: authselect current
   changed_when: false
   failed_when: discovered_authselect_faillock_state.rc not in [ 0, 1 ]
   register: discovered_authselect_faillock_state

--- a/tasks/Cat2/RHEL-09-271xxx.yml
+++ b/tasks/Cat2/RHEL-09-271xxx.yml
@@ -391,13 +391,18 @@
     - V-258029
     - NIST800-53R4_CM-6
   notify: Update_dconf
-  ansible.builtin.command: gsettings set org.gnome.login-screen disable-restart-buttons true
-  changed_when: true
+  community.general.ini_file:
+    path: "/etc/dconf/db/{{ item }}.d/02-login-screen"
+    section: org/gnome/login-screen
+    option: disable-restart-buttons
+    value: 'true'
+    create: true
+    mode: 'go-wx'
   loop: "{{ prelim_dconf_db.stdout_lines }}"
 
 - name: "MEDIUM | RHEL-09-271100 | PATCH | RHEL 9 must prevent a user from overriding the disable-restart-buttons setting for the graphical user interface."
   when:
-    - mrhel_09_271100
+    - rhel_09_271100
     - "'dconf' in ansible_facts.packages"
   tags:
     - RHEL-09-271100

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -176,7 +176,7 @@
     - rhel_09_653110
   tags: always
   ansible.builtin.find:
-    path: etc/audit/rules.d
+    path: /etc/audit/rules.d
     patterns: '*.rules'
   register: discovered_audit_rules
 


### PR DESCRIPTION
## Summary

- replace the session-oriented RHEL-09-271095 `gsettings set` with a system-dconf keyfile update
- correct the RHEL-09-271100 gate typo so the dconf lock is applied
- use an absolute audit rule directory in the RHEL-09-653110 prelim discovery
- remove the unsupported/misspelled pipeline from the faillock handler by capturing `authselect current` directly

## Validation

- Ran a focused regression harness red before the implementation and green afterward.
- Parsed all changed YAML files with Ansible `DataLoader`.
- Ran `git diff --check`.
- Ran `ansible-playbook --syntax-check -i localhost, -c local molecule/default/converge.yml` using the declared collections.
- Ran the existing RHEL9-STIG-Audit Goss checks for RHEL-09-271095 and RHEL-09-271100; both passed on a GDM-enabled RHEL 9 host.

Fixes #166
Fixes #177
Fixes #178